### PR TITLE
Add input validation for commodity functions

### DIFF
--- a/R/bet_nets.R
+++ b/R/bet_nets.R
@@ -19,7 +19,26 @@
 #' Uses a version of the net stock and flow model as described by:
 #' Bertozzi-Villa, Amelia, et al. Nature communications 12.1 (2021): 1-12.
 commodity_nets <- function(usage, use_rate, distribution_timesteps, crop_timesteps, half_life, par, ...){
-  stopifnot(length(usage) == length(par))
+  stopifnot(
+    is.numeric(usage),
+    is.numeric(use_rate),
+    is.numeric(distribution_timesteps),
+    is.numeric(crop_timesteps),
+    is.numeric(half_life),
+    is.numeric(par)
+  )
+  stopifnot(
+    all(usage >= 0 & usage <= 1),
+    all(use_rate >= 0 & use_rate <= 1),
+    all(distribution_timesteps >= 0),
+    all(crop_timesteps >= 0),
+    half_life >= 0,
+    all(par >= 0)
+  )
+  stopifnot(
+    length(half_life) == 1,
+    length(usage) == length(par)
+  )
 
   access <- netz::usage_to_access(usage = usage, use_rate = use_rate)
   crop <- netz::access_to_crop(access = access)

--- a/R/dx_tx.R
+++ b/R/dx_tx.R
@@ -5,6 +5,24 @@
 #' @param proportion_rdt Proportion of diagnostics that are RDT
 #' @param proportion_tested Proportion of treated cases that are tested
 commodity_rdt_tests <- function(n_cases, treatment_coverage, proportion_rdt, proportion_tested = 1){
+  stopifnot(
+    is.numeric(n_cases),
+    is.numeric(treatment_coverage),
+    is.numeric(proportion_rdt),
+    is.numeric(proportion_tested)
+  )
+  stopifnot(
+    all(n_cases >= 0),
+    all(treatment_coverage >= 0 & treatment_coverage <= 1),
+    all(proportion_rdt >= 0 & proportion_rdt <= 1),
+    all(proportion_tested >= 0 & proportion_tested <= 1)
+  )
+  stopifnot(
+    length(n_cases) == length(treatment_coverage),
+    length(n_cases) == length(proportion_rdt),
+    length(proportion_tested) == 1
+  )
+
   round(n_cases * treatment_coverage * proportion_rdt * proportion_tested)
 }
 
@@ -13,6 +31,24 @@ commodity_rdt_tests <- function(n_cases, treatment_coverage, proportion_rdt, pro
 #' @inheritParams commodity_rdt_tests
 #' @param proportion_microscopy Proportion of diagnostics that are microscopy
 commodity_microscopy_tests <- function(n_cases, treatment_coverage, proportion_microscopy, proportion_tested = 1){
+  stopifnot(
+    is.numeric(n_cases),
+    is.numeric(treatment_coverage),
+    is.numeric(proportion_microscopy),
+    is.numeric(proportion_tested)
+  )
+  stopifnot(
+    all(n_cases >= 0),
+    all(treatment_coverage >= 0 & treatment_coverage <= 1),
+    all(proportion_microscopy >= 0 & proportion_microscopy <= 1),
+    all(proportion_tested >= 0 & proportion_tested <= 1)
+  )
+  stopifnot(
+    length(n_cases) == length(treatment_coverage),
+    length(n_cases) == length(proportion_microscopy),
+    length(proportion_tested) == 1
+  )
+
   round(n_cases * treatment_coverage * proportion_microscopy * proportion_tested)
 }
 
@@ -25,6 +61,30 @@ commodity_microscopy_tests <- function(n_cases, treatment_coverage, proportion_m
 #' @param pfpr Prevalence
 #' @param pfpr_threshold Prevalence threshold at which it is assummed NMF are not suspected (and subsequently tested) to be malaria
 commodity_nmf_rdt_tests <- function(n_nmf, treatment_coverage, proportion_rdt, proportion_tested = 1, pfpr, pfpr_threshold = 0.05){
+  stopifnot(
+    is.numeric(n_nmf),
+    is.numeric(treatment_coverage),
+    is.numeric(proportion_rdt),
+    is.numeric(proportion_tested),
+    is.numeric(pfpr),
+    is.numeric(pfpr_threshold)
+  )
+  stopifnot(
+    all(n_nmf >= 0),
+    all(treatment_coverage >= 0 & treatment_coverage <= 1),
+    all(proportion_rdt >= 0 & proportion_rdt <= 1),
+    all(proportion_tested >= 0 & proportion_tested <= 1),
+    all(pfpr >= 0 & pfpr <= 1),
+    pfpr_threshold >= 0 & pfpr_threshold <= 1
+  )
+  stopifnot(
+    length(pfpr_threshold) == 1,
+    length(n_nmf) == length(treatment_coverage),
+    length(n_nmf) == length(proportion_rdt),
+    length(proportion_tested) == 1,
+    length(n_nmf) == length(pfpr)
+  )
+
   ifelse(pfpr > pfpr_threshold, round(n_nmf * treatment_coverage * proportion_rdt * proportion_tested), 0)
 }
 
@@ -33,6 +93,30 @@ commodity_nmf_rdt_tests <- function(n_nmf, treatment_coverage, proportion_rdt, p
 #' @param inheritparams commodity_nmf_rdt_tests
 #' @param proportion_microscopy Proportion of diagnostics that are microscopy
 commodity_nmf_microscopy_tests <- function(n_nmf, treatment_coverage, proportion_microscopy, proportion_tested = 1, pfpr, pfpr_threshold = 0.05){
+  stopifnot(
+    is.numeric(n_nmf),
+    is.numeric(treatment_coverage),
+    is.numeric(proportion_microscopy),
+    is.numeric(proportion_tested),
+    is.numeric(pfpr),
+    is.numeric(pfpr_threshold)
+  )
+  stopifnot(
+    all(n_nmf >= 0),
+    all(treatment_coverage >= 0 & treatment_coverage <= 1),
+    all(proportion_microscopy >= 0 & proportion_microscopy <= 1),
+    all(proportion_tested >= 0 & proportion_tested <= 1),
+    all(pfpr >= 0 & pfpr <= 1),
+    pfpr_threshold >= 0 & pfpr_threshold <= 1
+  )
+  stopifnot(
+    length(pfpr_threshold) == 1,
+    length(n_nmf) == length(treatment_coverage),
+    length(n_nmf) == length(proportion_microscopy),
+    length(proportion_tested) == 1,
+    length(n_nmf) == length(pfpr)
+  )
+
   ifelse(pfpr > pfpr_threshold, round(n_nmf * treatment_coverage * proportion_microscopy * proportion_tested), 0)
 }
 
@@ -59,8 +143,21 @@ commodity_nmf_microscopy_tests <- function(n_nmf, treatment_coverage, proportion
 #' @export
 commodity_al_doses <- function(n_cases, treatment_coverage, proportion_act, age_upper) {
   stopifnot(
+    is.numeric(n_cases),
+    is.numeric(treatment_coverage),
+    is.numeric(proportion_act),
+    is.numeric(age_upper)
+  )
+  stopifnot(
+    all(n_cases >= 0),
+    all(treatment_coverage >= 0 & treatment_coverage <= 1),
+    all(proportion_act >= 0 & proportion_act <= 1),
+    all(age_upper >= 0)
+  )
+  stopifnot(
     length(n_cases) == length(treatment_coverage),
-    length(n_cases) == length(age_upper)
+    length(n_cases) == length(age_upper),
+    length(n_cases) == length(proportion_act)
   )
 
   # Dose multipliers per age band (number of 20/120mg doses per course)
@@ -103,8 +200,27 @@ commodity_al_doses <- function(n_cases, treatment_coverage, proportion_act, age_
 #' @export
 commodity_nmf_al_doses <- function(n_nmf, treatment_coverage, proportion_act, age_upper, pfpr, pfpr_threshold = 0.05) {
   stopifnot(
+    is.numeric(n_nmf),
+    is.numeric(treatment_coverage),
+    is.numeric(proportion_act),
+    is.numeric(age_upper),
+    is.numeric(pfpr),
+    is.numeric(pfpr_threshold)
+  )
+  stopifnot(
+    all(n_nmf >= 0),
+    all(treatment_coverage >= 0 & treatment_coverage <= 1),
+    all(proportion_act >= 0 & proportion_act <= 1),
+    all(age_upper >= 0),
+    all(pfpr >= 0 & pfpr <= 1),
+    pfpr_threshold >= 0 & pfpr_threshold <= 1
+  )
+  stopifnot(
+    length(pfpr_threshold) == 1,
     length(n_nmf) == length(treatment_coverage),
-    length(n_nmf) == length(age_upper)
+    length(n_nmf) == length(age_upper),
+    length(n_nmf) == length(proportion_act),
+    length(n_nmf) == length(pfpr)
   )
 
   # Dose multipliers per age band (number of 20/120mg doses per course)

--- a/R/irs.R
+++ b/R/irs.R
@@ -7,7 +7,21 @@
 #' @return The total number of person-rounds of IRS protection.
 #' @export
 commodity_person_rounds_irs <- function(irs_cov, n_rounds, par){
-  stopifnot(length(irs_cov) == length(par))
+  stopifnot(
+    is.numeric(irs_cov),
+    is.numeric(n_rounds),
+    is.numeric(par)
+  )
+  stopifnot(
+    all(irs_cov >= 0 & irs_cov <= 1),
+    n_rounds >= 0,
+    all(par >= 0)
+  )
+  stopifnot(
+    length(n_rounds) == 1,
+    length(irs_cov) == length(par)
+  )
+
   round(irs_cov * n_rounds * par)
 }
 
@@ -21,8 +35,24 @@ commodity_person_rounds_irs <- function(irs_cov, n_rounds, par){
 #' @return The total number of structure-rounds of IRS protection.
 #' @export
 commodity_structure_rounds_irs <- function(irs_cov, n_rounds, par, hh_size){
-  stopifnot(length(irs_cov) == length(par))
-  stopifnot(length(hh_size) == 1)
+  stopifnot(
+    is.numeric(irs_cov),
+    is.numeric(n_rounds),
+    is.numeric(par),
+    is.numeric(hh_size)
+  )
+  stopifnot(
+    all(irs_cov >= 0 & irs_cov <= 1),
+    n_rounds >= 0,
+    all(par >= 0),
+    hh_size >= 0
+  )
+  stopifnot(
+    length(n_rounds) == 1,
+    length(hh_size) == 1,
+    length(irs_cov) == length(par)
+  )
+
   round((irs_cov * n_rounds * par) / hh_size)
 }
 

--- a/R/pmc.R
+++ b/R/pmc.R
@@ -7,7 +7,21 @@
 #' @return The total number of pmc doses delivered.
 #' @export
 commodity_doses_pmc <- function(pmc_cov, par_pmc, n_rounds = 3){
-  stopifnot(length(pmc_cov) == length(par_pmc))
+  stopifnot(
+    is.numeric(pmc_cov),
+    is.numeric(par_pmc),
+    is.numeric(n_rounds)
+  )
+  stopifnot(
+    all(pmc_cov >= 0 & pmc_cov <= 1),
+    n_rounds >= 0,
+    all(par_pmc >= 0)
+  )
+  stopifnot(
+    length(n_rounds) == 1,
+    length(pmc_cov) == length(par_pmc)
+  )
+
   round(pmc_cov * n_rounds * par_pmc)
 }
 

--- a/R/smc.R
+++ b/R/smc.R
@@ -7,7 +7,21 @@
 #' @return The total number of SMC doses delivered.
 #' @export
 commodity_doses_smc <- function(smc_cov, n_rounds, par_smc){
-  stopifnot(length(smc_cov) == length(par_smc))
+  stopifnot(
+    is.numeric(smc_cov),
+    is.numeric(n_rounds),
+    is.numeric(par_smc)
+  )
+  stopifnot(
+    all(smc_cov >= 0 & smc_cov <= 1),
+    n_rounds >= 0,
+    all(par_smc >= 0)
+  )
+  stopifnot(
+    length(n_rounds) == 1,
+    length(smc_cov) == length(par_smc)
+  )
+
   round(smc_cov * n_rounds * par_smc)
 }
 

--- a/R/vaccine.R
+++ b/R/vaccine.R
@@ -12,6 +12,27 @@
 #'
 #' @returns The total number of vaccine doses delivered.
 commodity_doses_vaccine <- function(vaccine_cov, par_vaccine, n_dose_primary_series = 3, booster_coverage_downscale = 0.8, n_boosters = 1){
+  stopifnot(
+    is.numeric(vaccine_cov),
+    is.numeric(par_vaccine),
+    is.numeric(n_dose_primary_series),
+    is.numeric(booster_coverage_downscale),
+    is.numeric(n_boosters)
+  )
+  stopifnot(
+    all(vaccine_cov >= 0 & vaccine_cov <= 1),
+    all(par_vaccine >= 0),
+    n_dose_primary_series >= 0,
+    all(booster_coverage_downscale >= 0 & booster_coverage_downscale <= 1),
+    n_boosters >= 0
+  )
+  stopifnot(
+    length(n_dose_primary_series) == 1,
+    length(booster_coverage_downscale) == 1,
+    length(n_boosters) == 1,
+    length(vaccine_cov) == length(par_vaccine)
+  )
+
   n_vaccine <- vaccine_cov * par_vaccine
   n_doses_rtss <- round((n_vaccine * n_dose_primary_series) + (n_vaccine * booster_coverage_downscale * n_boosters))
   return(n_doses_rtss)


### PR DESCRIPTION
## Summary
- validate numeric, scalar, range, and length properties for each commodity function
- ensure proportion_tested is a scalar across diagnostic calculations

## Testing
- `Rscript -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c35eb33d88326909a3379360aace1