### PR TITLE
Add export tags without manual NAMESPACE edits

### DIFF
--- a/R/bet_nets.R
+++ b/R/bet_nets.R
@@ -18,6 +18,7 @@
 #' @references
 #' Uses a version of the net stock and flow model as described by:
 #' Bertozzi-Villa, Amelia, et al. Nature communications 12.1 (2021): 1-12.
+#' @export
 commodity_nets <- function(usage, use_rate, distribution_timesteps, crop_timesteps, half_life, par, ...){
   stopifnot(length(usage) == length(par))
 

--- a/R/dx_tx.R
+++ b/R/dx_tx.R
@@ -4,6 +4,7 @@
 #' @param treatment_coverage Treatment coverage
 #' @param proportion_rdt Proportion of diagnostics that are RDT
 #' @param proportion_tested Proportion of treated cases that are tested
+#' @export
 commodity_rdt_tests <- function(n_cases, treatment_coverage, proportion_rdt, proportion_tested = 1){
   round(n_cases * treatment_coverage * proportion_rdt * proportion_tested)
 }
@@ -12,6 +13,7 @@ commodity_rdt_tests <- function(n_cases, treatment_coverage, proportion_rdt, pro
 #'
 #' @inheritParams commodity_rdt_tests
 #' @param proportion_microscopy Proportion of diagnostics that are microscopy
+#' @export
 commodity_microscopy_tests <- function(n_cases, treatment_coverage, proportion_microscopy, proportion_tested = 1){
   round(n_cases * treatment_coverage * proportion_microscopy * proportion_tested)
 }
@@ -24,6 +26,7 @@ commodity_microscopy_tests <- function(n_cases, treatment_coverage, proportion_m
 #' @param proportion_tested Proportion of nmfs that are tested
 #' @param pfpr Prevalence
 #' @param pfpr_threshold Prevalence threshold at which it is assummed NMF are not suspected (and subsequently tested) to be malaria
+#' @export
 commodity_nmf_rdt_tests <- function(n_nmf, treatment_coverage, proportion_rdt, proportion_tested = 1, pfpr, pfpr_threshold = 0.05){
   ifelse(pfpr > pfpr_threshold, round(n_nmf * treatment_coverage * proportion_rdt * proportion_tested), 0)
 }
@@ -32,6 +35,7 @@ commodity_nmf_rdt_tests <- function(n_nmf, treatment_coverage, proportion_rdt, p
 #'
 #' @param inheritparams commodity_nmf_rdt_tests
 #' @param proportion_microscopy Proportion of diagnostics that are microscopy
+#' @export
 commodity_nmf_microscopy_tests <- function(n_nmf, treatment_coverage, proportion_microscopy, proportion_tested = 1, pfpr, pfpr_threshold = 0.05){
   ifelse(pfpr > pfpr_threshold, round(n_nmf * treatment_coverage * proportion_microscopy * proportion_tested), 0)
 }

--- a/R/vaccine.R
+++ b/R/vaccine.R
@@ -11,6 +11,7 @@
 #' @param n_boosters Number of booster doses
 #'
 #' @returns The total number of vaccine doses delivered.
+#' @export
 commodity_doses_vaccine <- function(vaccine_cov, par_vaccine, n_dose_primary_series = 3, booster_coverage_downscale = 0.8, n_boosters = 1){
   n_vaccine <- vaccine_cov * par_vaccine
   n_doses_rtss <- round((n_vaccine * n_dose_primary_series) + (n_vaccine * booster_coverage_downscale * n_boosters))


### PR DESCRIPTION
## Summary
- ensure `commodity_nets` and diagnostic helper functions are exported
- export vaccine dose helper
- revert manual edits to `NAMESPACE`

## Testing
- `Rscript -e "devtools::test()"` *(fails: Rscript not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c35ddbc6c8326884c2dae3dcfedb0