### PR TITLE
Fix documentation typos

### DIFF
--- a/R/bet_nets.R
+++ b/R/bet_nets.R
@@ -1,15 +1,15 @@
 #' Estimate the number of bed nets required to match usage target
 #'
-#' @param itn_use A single value or vector of desired target usages to model.
+#' @param usage A single value or vector of desired target usages to model.
 #' @param use_rate A single value or vector of usage rates.
 #' @param distribution_timesteps Timesteps of distributions (days). By default,
 #' we can assume that net distributions happen on the first day of each year.
 #' For example c(1, 366)
 #' @param crop_timesteps Timesteps of crop estimates (days). If assuming distribtions
-#' occur on the first day of each year, a reasonable asumption would be that the
+#' occur on the first day of each year, a reasonable assumption would be that the
 #' crop (and therefore corresponding usage) estimates were taken at the mid-point of each year.
 #' For example c(1, 366) + 183.
-#' @param half_life Country-specific) half-life of nets in days.
+#' @param half_life Country-specific half-life of nets in days.
 #' @param par Population at risk estimates.
 #' @param ... additional arguments for the crop_to_distribution function in netz
 #'

--- a/R/dx_tx.R
+++ b/R/dx_tx.R
@@ -23,7 +23,7 @@ commodity_microscopy_tests <- function(n_cases, treatment_coverage, proportion_m
 #' @param proportion_rdt Proportion of diagnostics that are RDT
 #' @param proportion_tested Proportion of nmfs that are tested
 #' @param pfpr Prevalence
-#' @param pfpr_threshold Prevalence threshold at which it is assummed NMF are not suspected (and subsequently tested) to be malaria
+#' @param pfpr_threshold Prevalence threshold at which it is assumed NMF are not suspected (and subsequently tested) to be malaria
 commodity_nmf_rdt_tests <- function(n_nmf, treatment_coverage, proportion_rdt, proportion_tested = 1, pfpr, pfpr_threshold = 0.05){
   ifelse(pfpr > pfpr_threshold, round(n_nmf * treatment_coverage * proportion_rdt * proportion_tested), 0)
 }

--- a/R/pmc.R
+++ b/R/pmc.R
@@ -2,7 +2,7 @@
 #'
 #' @param pmc_cov A single value or vector of pmc coverage.
 #' @param n_rounds The number of pmc rounds per year
-#' @param par_pmc Population at risk within pmc-eligable age range estimates.
+#' @param par_pmc Population at risk within pmc-eligible age range estimates.
 #'
 #' @return The total number of pmc doses delivered.
 #' @export


### PR DESCRIPTION
## Summary
- correct param names in `commodity_nets` docs
- fix spelling issues in documentation
- revert manual Rd file edits

## Testing
- `R -q -e "devtools::document()"` *(fails: command not found)*
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c35dc58c48326bb22e5f0ae965ec4