### PR TITLE
Add tests for commodity utilities

### DIFF
--- a/tests/testthat/test-bed-nets.R
+++ b/tests/testthat/test-bed-nets.R
@@ -33,3 +33,37 @@ test_that("Pyrethroid-chlorfenapyr costing", {
   expect_error(cost_dualai_itn(n_dualai_itn = 1, dualai_itn_unit_cost = -1), "Dual ai cost inputs must be >= 0")
   expect_error(cost_dualai_itn(n_dualai_itn = 1, dualai_itn_delivery_cost = -1), "Dual ai cost inputs must be >= 0")
 })
+
+test_that("Commodity nets", {
+  skip_if_not_installed("netz")
+  usage <- c(0.5, 0.6)
+  use_rate <- 0.5
+  dist_steps <- c(1, 366)
+  crop_steps <- dist_steps + 183
+  half_life <- 730
+  par <- c(100, 100)
+
+  expected <- {
+    access <- netz::usage_to_access(usage = usage, use_rate = use_rate)
+    crop <- netz::access_to_crop(access = access)
+    dist <- netz::crop_to_distribution(
+      crop = crop,
+      crop_timesteps = crop_steps,
+      distribution_timesteps = dist_steps,
+      half_life = half_life
+    )
+    round(dist * par)
+  }
+
+  expect_equal(
+    commodity_nets(
+      usage = usage,
+      use_rate = use_rate,
+      distribution_timesteps = dist_steps,
+      crop_timesteps = crop_steps,
+      half_life = half_life,
+      par = par
+    ),
+    expected
+  )
+})

--- a/tests/testthat/test-dx_tx.R
+++ b/tests/testthat/test-dx_tx.R
@@ -55,3 +55,68 @@ test_that("WHO CHOICE costing", {
   expect_error(cost_inpatient(n_visits = -1, cost_per_day = 1), "All n_visits estimates must be >= 0")
   expect_error(cost_inpatient(n_visits = 1, cost_per_day = -1), "Inpatient cost inputs must be >= 0")
 })
+
+test_that("commodity diagnostic calculations", {
+  expect_equal(
+    commodity_rdt_tests(n_cases = 100, treatment_coverage = 0.5, proportion_rdt = 0.8, proportion_tested = 0.5),
+    round(100 * 0.5 * 0.8 * 0.5)
+  )
+  expect_equal(
+    commodity_microscopy_tests(n_cases = c(100, 50), treatment_coverage = c(0.5, 0.5), proportion_microscopy = c(0.6, 0.4), proportion_tested = 1),
+    round(c(100 * 0.5 * 0.6 * 1, 50 * 0.5 * 0.4 * 1))
+  )
+
+  expect_equal(
+    commodity_nmf_rdt_tests(n_nmf = 10, treatment_coverage = 0.5, proportion_rdt = 1, proportion_tested = 1, pfpr = 0.1, pfpr_threshold = 0.05),
+    round(10 * 0.5 * 1 * 1)
+  )
+  expect_equal(
+    commodity_nmf_rdt_tests(n_nmf = 10, treatment_coverage = 0.5, proportion_rdt = 1, proportion_tested = 1, pfpr = 0.02, pfpr_threshold = 0.05),
+    0
+  )
+
+  expect_equal(
+    commodity_nmf_microscopy_tests(n_nmf = 10, treatment_coverage = 0.5, proportion_microscopy = 1, proportion_tested = 1, pfpr = 0.1, pfpr_threshold = 0.05),
+    round(10 * 0.5 * 1 * 1)
+  )
+  expect_equal(
+    commodity_nmf_microscopy_tests(n_nmf = 10, treatment_coverage = 0.5, proportion_microscopy = 1, proportion_tested = 1, pfpr = 0.03, pfpr_threshold = 0.05),
+    0
+  )
+})
+
+test_that("commodity treatment doses", {
+  expect_equal(
+    commodity_al_doses(
+      n_cases = c(10, 20, 30),
+      treatment_coverage = c(1, 1, 1),
+      proportion_act = c(1, 1, 1),
+      age_upper = c(5, 15, 20)
+    ),
+    c(60, 300, 720)
+  )
+
+  expect_equal(
+    commodity_nmf_al_doses(
+      n_nmf = c(10, 20, 30),
+      treatment_coverage = c(1, 1, 1),
+      proportion_act = c(1, 1, 1),
+      age_upper = c(5, 15, 20),
+      pfpr = c(0.1, 0.06, 0.1),
+      pfpr_threshold = 0.05
+    ),
+    round(c(10, 20, 30) * c(0.1, 0.06, 0.1) * c(1, 1, 1) * c(1, 1, 1) * c(6, 15, 24))
+  )
+
+  expect_equal(
+    commodity_nmf_al_doses(
+      n_nmf = 10,
+      treatment_coverage = 1,
+      proportion_act = 1,
+      age_upper = 5,
+      pfpr = 0.01,
+      pfpr_threshold = 0.05
+    ),
+    0
+  )
+})

--- a/tests/testthat/test-irs.R
+++ b/tests/testthat/test-irs.R
@@ -19,3 +19,39 @@ test_that("IRS costing", {
   expect_error(cost_ll_irs_structure(n_sprayed = -1), "All n_sprayed estimates must be >= 0")
   expect_error(cost_ll_irs_structure(n_sprayed = 1, cost_per_structure_sprayed = -1), "Long lasting IRS cost inputs must be >= 0")
 })
+
+test_that("IRS commodity people rounds", {
+  expect_equal(
+    commodity_person_rounds_irs(irs_cov = 0.5, n_rounds = 2, par = 100),
+    round(0.5 * 2 * 100)
+  )
+  expect_equal(
+    commodity_person_rounds_irs(irs_cov = c(0.1, 0.2), n_rounds = 3, par = c(100, 50)),
+    round(c(0.1 * 3 * 100, 0.2 * 3 * 50))
+  )
+  expect_error(
+    commodity_person_rounds_irs(irs_cov = c(0.1, 0.2), n_rounds = 3, par = 100),
+    "length(irs_cov) == length(par)"
+  )
+})
+
+test_that("IRS commodity structure rounds", {
+  expect_equal(
+    commodity_structure_rounds_irs(irs_cov = 0.5, n_rounds = 2, par = 100, hh_size = 5),
+    round((0.5 * 2 * 100) / 5)
+  )
+  expect_equal(
+    commodity_structure_rounds_irs(
+      irs_cov = c(0.2, 0.4), n_rounds = 1, par = c(50, 50), hh_size = 5
+    ),
+    round(c(0.2 * 1 * 50, 0.4 * 1 * 50) / 5)
+  )
+  expect_error(
+    commodity_structure_rounds_irs(irs_cov = c(0.2, 0.4), n_rounds = 1, par = 50, hh_size = 5),
+    "length(irs_cov) == length(par)"
+  )
+  expect_error(
+    commodity_structure_rounds_irs(irs_cov = 0.2, n_rounds = 1, par = 50, hh_size = c(5, 5)),
+    "length(hh_size) == 1"
+  )
+})

--- a/tests/testthat/test-pmc.R
+++ b/tests/testthat/test-pmc.R
@@ -8,3 +8,18 @@ test_that("PMC costing", {
   expect_error(cost_pmc(n_doses = -1), "All n_doses estimates must be >= 0")
   expect_error(cost_pmc(n_doses = 1, pmc_cost_per_dose_delivered = -1), "PMC cost inputs must be >= 0")
 })
+
+test_that("PMC commodity doses", {
+  expect_equal(
+    commodity_doses_pmc(pmc_cov = 0.5, par_pmc = 100, n_rounds = 3),
+    round(0.5 * 3 * 100)
+  )
+  expect_equal(
+    commodity_doses_pmc(pmc_cov = c(0.1, 0.2), par_pmc = c(100, 50), n_rounds = 3),
+    round(c(0.1 * 3 * 100, 0.2 * 3 * 50))
+  )
+  expect_error(
+    commodity_doses_pmc(pmc_cov = c(0.1, 0.2), par_pmc = 100, n_rounds = 3),
+    "length(pmc_cov) == length(par_pmc)"
+  )
+})

--- a/tests/testthat/test-smc.R
+++ b/tests/testthat/test-smc.R
@@ -8,3 +8,18 @@ test_that("SMC costing", {
   expect_error(cost_smc(n_doses = -1), "All n_doses estimates must be >= 0")
   expect_error(cost_smc(n_doses = 1, smc_cost_per_dose_delivered = -1), "SMC cost inputs must be >= 0")
 })
+
+test_that("SMC commodity doses", {
+  expect_equal(
+    commodity_doses_smc(smc_cov = 0.5, n_rounds = 4, par_smc = 100),
+    round(0.5 * 4 * 100)
+  )
+  expect_equal(
+    commodity_doses_smc(smc_cov = c(0.1, 0.2), n_rounds = 3, par_smc = c(100, 50)),
+    round(c(0.1 * 3 * 100, 0.2 * 3 * 50))
+  )
+  expect_error(
+    commodity_doses_smc(smc_cov = c(0.1, 0.2), n_rounds = 3, par_smc = 100),
+    "length(smc_cov) == length(par_smc)"
+  )
+})

--- a/tests/testthat/test-vaccine.R
+++ b/tests/testthat/test-vaccine.R
@@ -27,3 +27,17 @@ test_that("R21 costing", {
   expect_error(cost_r21(n_doses = 1, r21_consumables_cost = -1), "R21 cost inputs must be >= 0")
   expect_error(cost_r21(n_doses = 1, r21_delivery_cost = -1), "R21 cost inputs must be >= 0")
 })
+
+test_that("Vaccine commodity doses", {
+  expect_equal(
+    commodity_doses_vaccine(vaccine_cov = 0.5, par_vaccine = 100),
+    round((0.5 * 100 * 3) + (0.5 * 100 * 0.8 * 1))
+  )
+  expect_equal(
+    commodity_doses_vaccine(vaccine_cov = c(0.5, 0.6), par_vaccine = c(100, 50)),
+    round(c(
+      (0.5 * 100 * 3) + (0.5 * 100 * 0.8 * 1),
+      (0.6 * 50 * 3) + (0.6 * 50 * 0.8 * 1)
+    ))
+  )
+})


### PR DESCRIPTION
## Summary
- create unit tests for every `commodity_*` helper
- skip the bed-net commodity test if `netz` isn't available

## Testing
- `devtools::test()` *(fails: R not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c344066a48326b08ab83283ef4569