### PR TITLE
Fix docs for NMF helpers and vaccine doses

### DIFF
--- a/R/dx_tx.R
+++ b/R/dx_tx.R
@@ -18,7 +18,7 @@ commodity_microscopy_tests <- function(n_cases, treatment_coverage, proportion_m
 
 #' Estimate total number of RDT diagnostics required as a result of non malarial fevers
 #'
-#' @param n_cases Vector of malaria case numbers
+#' @param n_nmf Vector of non malarial fever case numbers
 #' @param treatment_coverage Treatment coverage
 #' @param proportion_rdt Proportion of diagnostics that are RDT
 #' @param proportion_tested Proportion of nmfs that are tested
@@ -30,7 +30,7 @@ commodity_nmf_rdt_tests <- function(n_nmf, treatment_coverage, proportion_rdt, p
 
 #' Estimate total number of microscopy diagnostics required as a result of non malarial fevers
 #'
-#' @param inheritparams commodity_nmf_rdt_tests
+#' @inheritParams commodity_nmf_rdt_tests
 #' @param proportion_microscopy Proportion of diagnostics that are microscopy
 commodity_nmf_microscopy_tests <- function(n_nmf, treatment_coverage, proportion_microscopy, proportion_tested = 1, pfpr, pfpr_threshold = 0.05){
   ifelse(pfpr > pfpr_threshold, round(n_nmf * treatment_coverage * proportion_microscopy * proportion_tested), 0)

--- a/R/vaccine.R
+++ b/R/vaccine.R
@@ -10,7 +10,8 @@
 #' boosters such that `booster coverage = vaccine_cov * booster_coverage_downscale`
 #' @param n_boosters Number of booster doses
 #'
-#' @returns The total number of vaccine doses delivered.
+#' @return The total number of vaccine doses delivered.
+#' @export
 commodity_doses_vaccine <- function(vaccine_cov, par_vaccine, n_dose_primary_series = 3, booster_coverage_downscale = 0.8, n_boosters = 1){
   n_vaccine <- vaccine_cov * par_vaccine
   n_doses_rtss <- round((n_vaccine * n_dose_primary_series) + (n_vaccine * booster_coverage_downscale * n_boosters))


### PR DESCRIPTION
## Summary
- document NMF helper functions using `n_nmf` param and inherit params correctly
- export vaccine dose helper and use `@return`
- reverted generated documentation files so only source docs change

## Testing
- `Rscript -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c35e4a81483269cea7ca119a091b6