### PR TITLE
Add missing tests for microscopy and inflation

### DIFF
--- a/R/dx_tx.R
+++ b/R/dx_tx.R
@@ -378,7 +378,7 @@ cost_microscopy <- function(n_tests, cost_per_slide = 0.67){
   if(any(n_tests < 0)){
     stop("All n_tests estimates must be >= 0")
   }
-  if(cost_per_slide < 0){
+  if(any(cost_per_slide < 0)){
     stop("Microscopy cost inputs must be >= 0")
   }
 

--- a/R/inflate.R
+++ b/R/inflate.R
@@ -28,18 +28,18 @@ inflation_adjust <- function(cost, cost_year, target_year, region = "Sub-Saharan
     stop("cost, cost_year, and target_year must be single values")
   }
 
-  # Check presence in CPI data
-  if (!(cost_year %in% cpi$year)) {
-    stop(paste("cost_year not found in cpi dataset:", cost_year))
+  # Filter CPI data for region and check years exist
+  cpi_region <- cpi[cpi$region == region, ]
+  if (!(cost_year %in% cpi_region$year)) {
+    stop(paste("cost_year not found for region:", cost_year))
   }
-  if (!(target_year %in% cpi$year)) {
-    stop(paste("target_year not found in cpi dataset:", target_year))
+  if (!(target_year %in% cpi_region$year)) {
+    stop(paste("target_year not found for region:", target_year))
   }
 
   # Retrieve CPI values
-  cpi <- cpi[cpi$region == region, ]
-  cpi_base   <- cpi$cpi[cpi$year == cost_year]
-  cpi_target <- cpi$cpi[cpi$year == target_year]
+  cpi_base   <- cpi_region$cpi[cpi_region$year == cost_year]
+  cpi_target <- cpi_region$cpi[cpi_region$year == target_year]
 
   # Compute and return adjusted cost
   cost * (cpi_target / cpi_base)

--- a/tests/testthat/test-dx_tx.R
+++ b/tests/testthat/test-dx_tx.R
@@ -11,6 +11,17 @@ test_that("RDT costing", {
   expect_error(cost_rdt(n_tests = 1, delivery_mark_up = -1), "RDT cost inputs must be >= 0")
 })
 
+test_that("Microscopy costing", {
+  expect_equal(cost_microscopy(n_tests = 1), 1 * 0.67)
+  expect_equal(cost_microscopy(n_tests = 2), 2 * 0.67)
+  expect_equal(cost_microscopy(n_tests = c(1, 2)), c(1, 2) * 0.67)
+
+  expect_equal(cost_microscopy(n_tests = 1, cost_per_slide = 2), 1 * 2)
+
+  expect_error(cost_microscopy(n_tests = -1), "All n_tests estimates must be >= 0")
+  expect_error(cost_microscopy(n_tests = 1, cost_per_slide = -1), "Microscopy cost inputs must be >= 0")
+})
+
 test_that("AL costing", {
   expect_equal(cost_al(n_doses = 1), 1 * 0.3)
   expect_equal(cost_al(n_doses = 2), 2 * 0.3)

--- a/tests/testthat/test-inflate.R
+++ b/tests/testthat/test-inflate.R
@@ -1,0 +1,12 @@
+test_that("inflation adjustment uses CPI ratios", {
+  cpi_region <- cpi[cpi$region == "Sub-Saharan Africa", ]
+  base <- cpi_region$cpi[cpi_region$year == 2007]
+  target <- cpi_region$cpi[cpi_region$year == 2024]
+  expect_equal(inflation_adjust(0.26, 2007, 2024), 0.26 * (target / base))
+})
+
+test_that("inflation adjustment input validation", {
+  expect_error(inflation_adjust(1, 1900, 2024), "cost_year not found")
+  expect_error(inflation_adjust(1, 2007, 3000), "target_year not found")
+  expect_error(inflation_adjust(c(1,2), 2007, 2024), "single values")
+})


### PR DESCRIPTION
## Summary
- fix cost_microscopy negative cost check
- improve inflation_adjust year validation
- add tests for cost_microscopy
- add new inflation_adjust tests

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fe63eb17c8326b735c6601038a7d7