### PR TITLE
Vectorise inflation_adjust and simplify cost functions

### DIFF
--- a/R/acd.R
+++ b/R/acd.R
@@ -4,6 +4,10 @@
 #'
 #' @param n_tested Number of people tested
 #' @param cost_per_person_tested Cost per person tested
+#' @param input_year Year the unit costs are reported in
+#' @param ... Additional arguments passed to `inflation_adjust()`
+#' @param input_year Year the unit costs are reported in
+#' @param ... Additional arguments passed to `inflation_adjust()`
 #'
 #' @return pACD costs
 #' @export
@@ -14,7 +18,8 @@
 #' Silumbe et al (2015)
 #'
 #' \url{https://malariajournal.biomedcentral.com/articles/10.1186/s12936-015-0722-3}.
-cost_pacd <- function(n_tested, cost_per_person_tested = 4.79){
+cost_pacd <- function(n_tested, cost_per_person_tested = 4.79, input_year = 1999,
+                      ...){
   if(any(n_tested < 0)){
     stop("All n_tested estimates must be >= 0")
   }
@@ -22,7 +27,8 @@ cost_pacd <- function(n_tested, cost_per_person_tested = 4.79){
     stop("pACD cost inputs must be >= 0")
   }
 
-  cost <- n_tested * cost_per_person_tested
+  unit_cost <- inflation_adjust(cost_per_person_tested, input_year, ...)
+  cost <- n_tested * unit_cost
   return(cost)
 }
 
@@ -42,7 +48,8 @@ cost_pacd <- function(n_tested, cost_per_person_tested = 4.79){
 #' Larson et al (2016)
 #'
 #' \url{https://malariajournal.biomedcentral.com/articles/10.1186/s12936-016-1457-5}.
-cost_racd <- function(n_tested, cost_per_person_tested = 38.63){
+cost_racd <- function(n_tested, cost_per_person_tested = 38.63, input_year = 1999,
+                      ...){
   if(any(n_tested < 0)){
     stop("All n_tested estimates must be >= 0")
   }
@@ -50,6 +57,7 @@ cost_racd <- function(n_tested, cost_per_person_tested = 38.63){
     stop("rACD cost inputs must be >= 0")
   }
 
-  cost <- n_tested * cost_per_person_tested
+  unit_cost <- inflation_adjust(cost_per_person_tested, input_year, ...)
+  cost <- n_tested * unit_cost
   return(cost)
 }

--- a/R/bet_nets.R
+++ b/R/bet_nets.R
@@ -59,6 +59,8 @@ commodity_nets <- function(usage, use_rate, distribution_timesteps, crop_timeste
 #' @param n_llin Number of standard LLIN bed nets
 #' @param llin_unit_cost Commodity unit cost per standard LLIN bed net.
 #' @param llin_delivery_cost Cost to deliver one standard LLIN bet net.
+#' @param input_year Year the unit costs are reported in
+#' @param ... Additional arguments passed to `inflation_adjust()`
 #'
 #' @return LLIN costs
 #' @export
@@ -78,7 +80,8 @@ commodity_nets <- function(usage, use_rate, distribution_timesteps, crop_timeste
 #' Sherrard-Smith et al (2022)
 #'
 #' \url{https://www.thelancet.com/journals/lanplh/article/PIIS2542-5196(21)00296-5/fulltext}.
-cost_llin <- function(n_llin, llin_unit_cost = 2.02, llin_delivery_cost = 1.50) {
+cost_llin <- function(n_llin, llin_unit_cost = 2.02, llin_delivery_cost = 1.50,
+                      input_year = 1999, ...) {
   if(any(n_llin < 0)){
     stop("All llin_n estimates must be >= 0")
   }
@@ -86,8 +89,9 @@ cost_llin <- function(n_llin, llin_unit_cost = 2.02, llin_delivery_cost = 1.50) 
     stop("LLIN cost inputs must be >= 0")
   }
 
-  cost_per_net_delivered <- llin_unit_cost + llin_delivery_cost
-  cost <- n_llin * cost_per_net_delivered
+  unit_cost <- llin_unit_cost + llin_delivery_cost
+  unit_cost <- inflation_adjust(unit_cost, input_year, ...)
+  cost <- n_llin * unit_cost
   return(cost)
 }
 
@@ -96,6 +100,8 @@ cost_llin <- function(n_llin, llin_unit_cost = 2.02, llin_delivery_cost = 1.50) 
 #' @param n_pbo_itn Number of pyrethroid-PBO bed nets
 #' @param pbo_itn_unit_cost Commodity unit cost per pyrethroid-PBO ITN bed net.
 #' @param pbo_itn_delivery_cost Cost to deliver one pyrethroid-PBO ITN bet net.
+#' @param input_year Year the unit costs are reported in
+#' @param ... Additional arguments passed to `inflation_adjust()`
 #'
 #' @return LLIN costs
 #' @export
@@ -114,7 +120,9 @@ cost_llin <- function(n_llin, llin_unit_cost = 2.02, llin_delivery_cost = 1.50) 
 #' Sherrard-Smith et al (2022)
 #'
 #' \url{https://www.thelancet.com/journals/lanplh/article/PIIS2542-5196(21)00296-5/fulltext}.
-cost_pbo_itn <- function(n_pbo_itn, pbo_itn_unit_cost = 2.63, pbo_itn_delivery_cost = 1.50) {
+cost_pbo_itn <- function(n_pbo_itn, pbo_itn_unit_cost = 2.63,
+                         pbo_itn_delivery_cost = 1.50, input_year = 1999,
+                         ...) {
   if(any(n_pbo_itn < 0)){
     stop("All llin_n estimates must be >= 0")
   }
@@ -122,8 +130,9 @@ cost_pbo_itn <- function(n_pbo_itn, pbo_itn_unit_cost = 2.63, pbo_itn_delivery_c
     stop("PBO cost inputs must be >= 0")
   }
 
-  cost_per_net_delivered <- pbo_itn_unit_cost + pbo_itn_delivery_cost
-  cost <- n_pbo_itn * cost_per_net_delivered
+  unit_cost <- pbo_itn_unit_cost + pbo_itn_delivery_cost
+  unit_cost <- inflation_adjust(unit_cost, input_year, ...)
+  cost <- n_pbo_itn * unit_cost
   return(cost)
 }
 
@@ -132,6 +141,8 @@ cost_pbo_itn <- function(n_pbo_itn, pbo_itn_unit_cost = 2.63, pbo_itn_delivery_c
 #' @param n_dualai_itn Number of pyrethroid-chlorfenapyr bed nets
 #' @param dualai_itn_unit_cost Commodity unit cost per pyrethroid-chlorfenapyr ITN bed net.
 #' @param dualai_itn_delivery_cost Cost to deliver one pyrethroid-chlorfenapyr ITN bet net.
+#' @param input_year Year the unit costs are reported in
+#' @param ... Additional arguments passed to `inflation_adjust()`
 #'
 #' @return LLIN costs
 #' @export
@@ -150,7 +161,9 @@ cost_pbo_itn <- function(n_pbo_itn, pbo_itn_unit_cost = 2.63, pbo_itn_delivery_c
 #' Sherrard-Smith et al (2022)
 #'
 #' \url{https://www.thelancet.com/journals/lanplh/article/PIIS2542-5196(21)00296-5/fulltext}.
-cost_dualai_itn <- function(n_dualai_itn, dualai_itn_unit_cost = 2.70, dualai_itn_delivery_cost = 1.50) {
+cost_dualai_itn <- function(n_dualai_itn, dualai_itn_unit_cost = 2.70,
+                            dualai_itn_delivery_cost = 1.50, input_year = 1999,
+                            ...) {
   if(any(n_dualai_itn < 0)){
     stop("All llin_n estimates must be >= 0")
   }
@@ -158,8 +171,9 @@ cost_dualai_itn <- function(n_dualai_itn, dualai_itn_unit_cost = 2.70, dualai_it
     stop("Dual ai cost inputs must be >= 0")
   }
 
-  cost_per_net_delivered <- dualai_itn_unit_cost + dualai_itn_delivery_cost
-  cost <- n_dualai_itn * cost_per_net_delivered
+  unit_cost <- dualai_itn_unit_cost + dualai_itn_delivery_cost
+  unit_cost <- inflation_adjust(unit_cost, input_year, ...)
+  cost <- n_dualai_itn * unit_cost
   return(cost)
 }
 

--- a/R/dx_tx.R
+++ b/R/dx_tx.R
@@ -324,7 +324,9 @@ commodity_nmf_al_doses <- function(n_nmf, treatment_coverage, proportion_act, ag
 #' @param n_tests Number of tests
 #' @param rdt_unit_cost Unit cost for rapid diagnostic test
 #' @param delivery_mark_up A mark up for in-country delivery to a public health facility.
-#' Expressed as a proportion of the test unit cost.
+#'   Expressed as a proportion of the test unit cost.
+#' @param input_year Year the unit costs are reported in
+#' @param ... Additional arguments passed to `inflation_adjust()`
 #'
 #' @return RDT costs
 #' @export
@@ -345,7 +347,8 @@ commodity_nmf_al_doses <- function(n_nmf, treatment_coverage, proportion_act, ag
 #' Patouillard et al (2017)
 #'
 #' \url{https://gh.bmj.com/content/2/2/e000176}
-cost_rdt <- function(n_tests, rdt_unit_cost = 0.46, delivery_mark_up = 0.15){
+cost_rdt <- function(n_tests, rdt_unit_cost = 0.46, delivery_mark_up = 0.15,
+                     input_year = 1999, ...){
   if(any(n_tests < 0)){
     stop("All n_tests estimates must be >= 0")
   }
@@ -353,8 +356,9 @@ cost_rdt <- function(n_tests, rdt_unit_cost = 0.46, delivery_mark_up = 0.15){
     stop("RDT cost inputs must be >= 0")
   }
 
-  cost_per_test_delivered <- rdt_unit_cost + (rdt_unit_cost * delivery_mark_up)
-  cost <- n_tests * cost_per_test_delivered
+  unit_cost <- rdt_unit_cost + (rdt_unit_cost * delivery_mark_up)
+  unit_cost <- inflation_adjust(unit_cost, input_year, ...)
+  cost <- n_tests * unit_cost
   return(cost)
 }
 
@@ -362,6 +366,8 @@ cost_rdt <- function(n_tests, rdt_unit_cost = 0.46, delivery_mark_up = 0.15){
 #'
 #' @param n_tests Number of tests
 #' @param cost_per_slide Cost per slide diagnostic performed
+#' @param input_year Year the unit costs are reported in
+#' @param ... Additional arguments passed to `inflation_adjust()`
 #'
 #' @return Microscopy costs
 #' @export
@@ -374,7 +380,8 @@ cost_rdt <- function(n_tests, rdt_unit_cost = 0.46, delivery_mark_up = 0.15){
 #' `inflation_adjust(0.26, 2007, 2024)`
 #'
 #' \url{https://pubmed.ncbi.nlm.nih.gov/18165484/}.
-cost_microscopy <- function(n_tests, cost_per_slide = 0.67){
+cost_microscopy <- function(n_tests, cost_per_slide = 0.67, input_year = 1999,
+                           ...){
   if(any(n_tests < 0)){
     stop("All n_tests estimates must be >= 0")
   }
@@ -382,7 +389,8 @@ cost_microscopy <- function(n_tests, cost_per_slide = 0.67){
     stop("Microscopy cost inputs must be >= 0")
   }
 
-  cost <- n_tests * cost_per_slide
+  unit_cost <- inflation_adjust(cost_per_slide, input_year, ...)
+  cost <- n_tests * unit_cost
   return(cost)
 }
 
@@ -392,6 +400,8 @@ cost_microscopy <- function(n_tests, cost_per_slide = 0.67){
 #'
 #' @param n_doses Number of doses
 #' @param cost_per_dose Cost per dose is for a single dose (20/120 mg)
+#' @param input_year Year the unit costs are reported in
+#' @param ... Additional arguments passed to `inflation_adjust()`
 #'
 #' @return AL costs
 #' @export
@@ -408,7 +418,8 @@ cost_microscopy <- function(n_tests, cost_per_slide = 0.67){
 #' The Global Fund Pooled Procurement Mechanism Reference Pricing: Antimalarial medicines, version: quarter 1, 2022
 #'
 #' \url{https://www.theglobalfund.org/en/sourcing-management/health-products/antimalarial-medicines/}.
-cost_al <- function(n_doses, cost_per_dose = 0.30){
+cost_al <- function(n_doses, cost_per_dose = 0.30, input_year = 1999,
+                    ...){
   if(any(n_doses < 0)){
     stop("All n_doses estimates must be >= 0")
   }
@@ -416,7 +427,8 @@ cost_al <- function(n_doses, cost_per_dose = 0.30){
     stop("AL cost inputs must be >= 0")
   }
 
-  cost <- n_doses * cost_per_dose
+  unit_cost <- inflation_adjust(cost_per_dose, input_year, ...)
+  cost <- n_doses * unit_cost
   return(cost)
 }
 
@@ -424,6 +436,8 @@ cost_al <- function(n_doses, cost_per_dose = 0.30){
 #'
 #' @param n_doses Number of doses
 #' @param cost_per_dose Cost per dose is for a single dose (250mg base each)
+#' @param input_year Year the unit costs are reported in
+#' @param ... Additional arguments passed to `inflation_adjust()`
 #'
 #' @return Chloroquine costs
 #' @export
@@ -435,7 +449,8 @@ cost_al <- function(n_doses, cost_per_dose = 0.30){
 #' costs $0.10 total
 #'
 #' \url{https://www.msf.org/qa-act-now-get-malaria-treatment-works-africa}.
-cost_chloroquine <- function(n_doses, cost_per_dose = 0.10 / 10){
+cost_chloroquine <- function(n_doses, cost_per_dose = 0.10 / 10, input_year = 1999,
+                             ...){
   if(any(n_doses < 0)){
     stop("All n_doses estimates must be >= 0")
   }
@@ -443,7 +458,8 @@ cost_chloroquine <- function(n_doses, cost_per_dose = 0.10 / 10){
     stop("Chloroquine cost inputs must be >= 0")
   }
 
-  cost <- n_doses * cost_per_dose
+  unit_cost <- inflation_adjust(cost_per_dose, input_year, ...)
+  cost <- n_doses * unit_cost
   return(cost)
 }
 
@@ -456,6 +472,8 @@ cost_chloroquine <- function(n_doses, cost_per_dose = 0.10 / 10){
 #'
 #' @param n_doses Number of tests
 #' @param cost_per_dose Cost per dose is for a single dose (7.5 mg)
+#' @param input_year Year the unit costs are reported in
+#' @param ... Additional arguments passed to `inflation_adjust()`
 #'
 #' @return primaquine costs
 #' @export
@@ -472,7 +490,8 @@ cost_chloroquine <- function(n_doses, cost_per_dose = 0.10 / 10){
 #' The Global Fund Pooled Procurement Mechanism Reference Pricing: Antimalarial medicines, version: quarter 1, 2022
 #'
 #' \url{https://www.theglobalfund.org/en/sourcing-management/health-products/antimalarial-medicines/}.
-cost_primaquine <- function(n_doses, cost_per_dose = 0.40){
+cost_primaquine <- function(n_doses, cost_per_dose = 0.40, input_year = 1999,
+                            ...){
   if(any(n_doses < 0)){
     stop("All n_doses estimates must be >= 0")
   }
@@ -480,7 +499,8 @@ cost_primaquine <- function(n_doses, cost_per_dose = 0.40){
     stop("Primaquine cost inputs must be >= 0")
   }
 
-  cost <- n_doses * cost_per_dose
+  unit_cost <- inflation_adjust(cost_per_dose, input_year, ...)
+  cost <- n_doses * unit_cost
   return(cost)
 }
 
@@ -490,10 +510,13 @@ cost_primaquine <- function(n_doses, cost_per_dose = 0.40){
 #'
 #' @param n_visits Number of visits
 #' @param cost_per_visit Cost per visit
+#' @param input_year Year the unit costs are reported in
+#' @param ... Additional arguments passed to `inflation_adjust()`
 #'
 #' @return Outpatient costs
 #' @export
-cost_outpatient <- function(n_visits, cost_per_visit){
+cost_outpatient <- function(n_visits, cost_per_visit, input_year = 1999,
+                           ...){
   if(any(n_visits < 0)){
     stop("All n_visits estimates must be >= 0")
   }
@@ -501,7 +524,8 @@ cost_outpatient <- function(n_visits, cost_per_visit){
     stop("Outpatient cost inputs must be >= 0")
   }
 
-  cost <- n_visits * cost_per_visit
+  unit_cost <- inflation_adjust(cost_per_visit, input_year, ...)
+  cost <- n_visits * unit_cost
   return(cost)
 }
 
@@ -512,10 +536,14 @@ cost_outpatient <- function(n_visits, cost_per_visit){
 #' @param n_visits Number of visits
 #' @param cost_per_day Cost per day
 #' @param average_stay_duration Average duration of stay, defaults to 3 days following Patouillard et al 2017.
+#' @param input_year Year the unit costs are reported in
+#' @param ... Additional arguments passed to `inflation_adjust()`
 #'
 #' @return Inpatient costs
 #' @export
-cost_inpatient <- function(n_visits, cost_per_day, average_stay_duration = 3){
+cost_inpatient <- function(n_visits, cost_per_day, average_stay_duration = 3,
+                          input_year = 1999,
+                          ...){
   if(any(n_visits < 0)){
     stop("All n_visits estimates must be >= 0")
   }
@@ -523,7 +551,8 @@ cost_inpatient <- function(n_visits, cost_per_day, average_stay_duration = 3){
     stop("Inpatient cost inputs must be >= 0")
   }
 
-  cost <- n_visits * cost_per_day * average_stay_duration
+  unit_cost <- inflation_adjust(cost_per_day, input_year, ...)
+  cost <- n_visits * unit_cost * average_stay_duration
   return(cost)
 }
 

--- a/R/inflate.R
+++ b/R/inflate.R
@@ -7,8 +7,10 @@
 #'
 #' @param cost Numeric value of the original cost.
 #' @param cost_year Integer indicating the year corresponding to `cost`.
-#' @param target_year Integer indicating the year to adjust the cost to.
-#' @param region World region, defaults to SSA
+#' @param target_year Integer indicating the year to adjust the cost to. If not
+#'   supplied, the value of `getOption("treasure.target_year")` is used.
+#' @param region World region. If not supplied, the value of
+#'   `getOption("treasure.region")` is used.
 #'
 #' @return Numeric value of the inflation-adjusted cost in `target_year` dollars.
 #'
@@ -17,30 +19,37 @@
 #' - `year`: Calendar year.
 #' - `cpi`: CPI index value for that year.
 #'
+#' This function is vectorised over all arguments.
+#'
 #' @examples
 #' # Adjust $0.26 from 2007 to 2024
 #' inflation_adjust(0.26, 2007, 2024)
 #'
 #' @export
-inflation_adjust <- function(cost, cost_year, target_year, region = "Sub-Saharan Africa") {
-  # Ensure single values
-  if (length(cost) != 1 || length(cost_year) != 1 || length(target_year) != 1) {
-    stop("cost, cost_year, and target_year must be single values")
+inflation_adjust <- function(cost, cost_year, target_year = NULL, region = NULL) {
+  if (is.null(target_year)) {
+    target_year <- getOption("treasure.target_year")
+  }
+  if (is.null(region)) {
+    region <- getOption("treasure.region")
   }
 
-  # Filter CPI data for region and check years exist
-  cpi_region <- cpi[cpi$region == region, ]
-  if (!(cost_year %in% cpi_region$year)) {
-    stop(paste("cost_year not found for region:", cost_year))
-  }
-  if (!(target_year %in% cpi_region$year)) {
-    stop(paste("target_year not found for region:", target_year))
-  }
+  n <- max(length(cost), length(cost_year), length(target_year), length(region))
+  cost <- rep(cost, length.out = n)
+  cost_year <- rep(cost_year, length.out = n)
+  target_year <- rep(target_year, length.out = n)
+  region <- rep(region, length.out = n)
 
-  # Retrieve CPI values
-  cpi_base   <- cpi_region$cpi[cpi_region$year == cost_year]
-  cpi_target <- cpi_region$cpi[cpi_region$year == target_year]
-
-  # Compute and return adjusted cost
-  cost * (cpi_target / cpi_base)
+  mapply(function(cst, cy, ty, reg) {
+    cpi_region <- cpi[cpi$region == reg, ]
+    if (!(cy %in% cpi_region$year)) {
+      stop(paste("cost_year not found for region:", cy))
+    }
+    if (!(ty %in% cpi_region$year)) {
+      stop(paste("target_year not found for region:", ty))
+    }
+    cpi_base   <- cpi_region$cpi[cpi_region$year == cy]
+    cpi_target <- cpi_region$cpi[cpi_region$year == ty]
+    cst * (cpi_target / cpi_base)
+  }, cost, cost_year, target_year, region, SIMPLIFY = TRUE)
 }

--- a/R/iptp.R
+++ b/R/iptp.R
@@ -2,6 +2,8 @@
 #'
 #' @param n_administrations Number of IPTp doses
 #' @param iptp_cost_per_administration Cost per dose delivered
+#' @param input_year Year the unit costs are reported in
+#' @param ... Additional arguments passed to `inflation_adjust()`
 #'
 #' @return IPTp costs
 #' @export
@@ -30,7 +32,8 @@
 #' Fernandes et al (2016). Table 2.
 #'
 #' \url{https://malariajournal.biomedcentral.com/articles/10.1186/s12936-016-1539-4}
-cost_iptp <- function(n_administrations, iptp_cost_per_administration = 0.79){
+cost_iptp <- function(n_administrations, iptp_cost_per_administration = 0.79,
+                      input_year = 1999, ...){
   if(any(n_administrations < 0)){
     stop("All n_administrations estimates must be >= 0")
   }
@@ -38,6 +41,8 @@ cost_iptp <- function(n_administrations, iptp_cost_per_administration = 0.79){
     stop("IPTp cost inputs must be >= 0")
   }
 
-  cost <- n_administrations * iptp_cost_per_administration
+  unit_cost <- inflation_adjust(iptp_cost_per_administration, input_year,
+                                ...)
+  cost <- n_administrations * unit_cost
   return(cost)
 }

--- a/R/irs.R
+++ b/R/irs.R
@@ -60,6 +60,8 @@ commodity_structure_rounds_irs <- function(irs_cov, n_rounds, par, hh_size){
 #'
 #' @param n_protected Number of people protected
 #' @param cost_per_person_protected Cost per person protected
+#' @param input_year Year the unit costs are reported in
+#' @param ... Additional arguments passed to `inflation_adjust()`
 #'
 #' @return Long lasting IRS costs
 #' @export
@@ -76,14 +78,18 @@ commodity_structure_rounds_irs <- function(irs_cov, n_rounds, par, hh_size){
 #' PMI IRS Country Programs: 2020, Comparative Cost Analysis, table CC2
 #'
 #' \url{https://www.pmi.gov/pmi-vectorlink-cost-study-report_2020_approved-june-14-2021-sxf-508/}.
-cost_ll_irs_person <- function(n_protected, cost_per_person_protected = 7.44){
+cost_ll_irs_person <- function(n_protected, cost_per_person_protected = 7.44,
+                               input_year = 1999,
+                               ...){
   if(any(n_protected < 0)){
     stop("All n_protected estimates must be >= 0")
   }
   if(any(cost_per_person_protected < 0)){
     stop("Long lasting IRS cost inputs must be >= 0")
   }
-  cost <- n_protected * cost_per_person_protected
+  unit_cost <- inflation_adjust(cost_per_person_protected, input_year,
+                                ...)
+  cost <- n_protected * unit_cost
   return(cost)
 }
 
@@ -91,6 +97,8 @@ cost_ll_irs_person <- function(n_protected, cost_per_person_protected = 7.44){
 #'
 #' @param n_sprayed Number of structures sprayed
 #' @param cost_per_structure_sprayed Cost per structure sprayed
+#' @param input_year Year the unit costs are reported in
+#' @param ... Additional arguments passed to `inflation_adjust()`
 #'
 #' @return Long lasting IRS costs
 #' @export
@@ -107,13 +115,17 @@ cost_ll_irs_person <- function(n_protected, cost_per_person_protected = 7.44){
 #' PMI IRS Country Programs: 2020, Comparative Cost Analysis, table CC2
 #'
 #' \url{https://www.pmi.gov/pmi-vectorlink-cost-study-report_2020_approved-june-14-2021-sxf-508/}.
-cost_ll_irs_structure <- function(n_sprayed, cost_per_structure_sprayed = 26.36){
+cost_ll_irs_structure <- function(n_sprayed, cost_per_structure_sprayed = 26.36,
+                                  input_year = 1999,
+                                  ...){
   if(any(n_sprayed < 0)){
     stop("All n_sprayed estimates must be >= 0")
   }
   if(any(cost_per_structure_sprayed < 0)){
     stop("Long lasting IRS cost inputs must be >= 0")
   }
-  cost <- n_sprayed * cost_per_structure_sprayed
+  unit_cost <- inflation_adjust(cost_per_structure_sprayed, input_year,
+                                ...)
+  cost <- n_sprayed * unit_cost
   return(cost)
 }

--- a/R/pmc.R
+++ b/R/pmc.R
@@ -29,6 +29,8 @@ commodity_doses_pmc <- function(pmc_cov, par_pmc, n_rounds = 3){
 #'
 #' @param n_doses Number of PMC doses
 #' @param pmc_cost_per_dose_delivered Cost per dose delivered
+#' @param input_year Year the unit costs are reported in
+#' @param ... Additional arguments passed to `inflation_adjust()`
 #'
 #' @return PMC costs
 #' @export
@@ -46,7 +48,9 @@ commodity_doses_pmc <- function(pmc_cov, par_pmc, n_rounds = 3){
 #' Conteh et al (2010) table S4
 #'
 #' \url{https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0010313}.
-cost_pmc <- function(n_doses, pmc_cost_per_dose_delivered = 0.3894){
+cost_pmc <- function(n_doses, pmc_cost_per_dose_delivered = 0.3894,
+                     input_year = 1999,
+                     ...){
   if(any(n_doses < 0)){
     stop("All n_doses estimates must be >= 0")
   }
@@ -54,6 +58,8 @@ cost_pmc <- function(n_doses, pmc_cost_per_dose_delivered = 0.3894){
     stop("PMC cost inputs must be >= 0")
   }
 
-  cost <- n_doses * pmc_cost_per_dose_delivered
+  unit_cost <- inflation_adjust(pmc_cost_per_dose_delivered, input_year,
+                                ...)
+  cost <- n_doses * unit_cost
   return(cost)
 }

--- a/R/set_region.R
+++ b/R/set_region.R
@@ -1,0 +1,6 @@
+#' Set the global region for inflation adjustments
+#'
+#' @param region Target region to use when adjusting for inflation
+set_region <- function(region) {
+  options(treasure.region = region)
+}

--- a/R/set_target_year.R
+++ b/R/set_target_year.R
@@ -1,0 +1,6 @@
+#' Set the global target year for inflation adjustments
+#'
+#' @param year Target year to use when adjusting for inflation
+set_target_year <- function(year) {
+  options(treasure.target_year = year)
+}

--- a/R/smc.R
+++ b/R/smc.R
@@ -29,6 +29,8 @@ commodity_doses_smc <- function(smc_cov, n_rounds, par_smc){
 #'
 #' @param n_doses Number of SMC doses
 #' @param smc_cost_per_dose_delivered Cost per dose delivered
+#' @param input_year Year the unit costs are reported in
+#' @param ... Additional arguments passed to `inflation_adjust()`
 #'
 #' @return SMC costs
 #' @export
@@ -48,7 +50,9 @@ commodity_doses_smc <- function(smc_cov, n_rounds, par_smc){
 #' Gilmartin et al (2021)
 #'
 #' \url{https://www.thelancet.com/journals/langlo/article/PIIS2214-109X(20)30475-7/fulltext}.
-cost_smc <- function(n_doses, smc_cost_per_dose_delivered = 0.9075){
+cost_smc <- function(n_doses, smc_cost_per_dose_delivered = 0.9075,
+                     input_year = 1999,
+                     ...){
   if(any(n_doses < 0)){
     stop("All n_doses estimates must be >= 0")
   }
@@ -56,6 +60,8 @@ cost_smc <- function(n_doses, smc_cost_per_dose_delivered = 0.9075){
     stop("SMC cost inputs must be >= 0")
   }
 
-  cost <- n_doses * smc_cost_per_dose_delivered
+  unit_cost <- inflation_adjust(smc_cost_per_dose_delivered, input_year,
+                                ...)
+  cost <- n_doses * unit_cost
   return(cost)
 }

--- a/R/surveillance.R
+++ b/R/surveillance.R
@@ -4,6 +4,8 @@
 #'
 #' @param pop_at_risk Population at risk
 #' @param cost_per_pop_at_risk Cost per population at risk
+#' @param input_year Year the unit costs are reported in
+#' @param ... Additional arguments passed to `inflation_adjust()`
 #'
 #' @return Surveillance costs
 #' @export
@@ -15,7 +17,9 @@
 #' plans from: Botswana, Nigeria, India, Eritrea, Swaziland, Namibia.
 #'
 #' \url{https://gh.bmj.com/content/2/2/e000176}.
-cost_surveillance <- function(pop_at_risk, cost_per_pop_at_risk = 0.05){
+cost_surveillance <- function(pop_at_risk, cost_per_pop_at_risk = 0.05,
+                              input_year = 1999,
+                              ...){
   if(any(pop_at_risk < 0)){
     stop("All pop_at_risk estimates must be >= 0")
   }
@@ -23,6 +27,7 @@ cost_surveillance <- function(pop_at_risk, cost_per_pop_at_risk = 0.05){
     stop("Surveillance cost inputs must be >= 0")
   }
 
-  cost <- pop_at_risk * cost_per_pop_at_risk
+  unit_cost <- inflation_adjust(cost_per_pop_at_risk, input_year, ...)
+  cost <- pop_at_risk * unit_cost
   return(cost)
 }

--- a/R/vaccine.R
+++ b/R/vaccine.R
@@ -45,6 +45,8 @@ commodity_doses_vaccine <- function(vaccine_cov, par_vaccine, n_dose_primary_ser
 #' @param rtss_cost_per_dose Cost per RTS,S dose
 #' @param rtss_consumables_cost Cost for consumables for one dose (e.g injection and reconstitution syringes, safety box etc.)
 #' @param rtss_delivery_cost Cost for delivery of one dose
+#' @param input_year Year the unit costs are reported in
+#' @param ... Additional arguments passed to `inflation_adjust()`
 #'
 #' @return RTS,S costs
 #' @export
@@ -55,15 +57,19 @@ commodity_doses_vaccine <- function(vaccine_cov, par_vaccine, n_dose_primary_ser
 #' Current default is based on the EUR9.30 per dose quoted in
 #' \url{https://www.unicef.org/supply/media/19456/file/Malaria\%20-\%20Vaccine\%20-\%20QA\%20-\%20October\%202023\%20-\%20English\%20.pdf}
 #'
-cost_rtss <- function(n_doses, rtss_cost_per_dose = 10.02, rtss_consumables_cost = 1.52, rtss_delivery_cost = 1.48){
+cost_rtss <- function(n_doses, rtss_cost_per_dose = 10.02,
+                      rtss_consumables_cost = 1.52, rtss_delivery_cost = 1.48,
+                      input_year = 1999,
+                      ...){
   if(any(n_doses < 0)){
     stop("All n_doses estimates must be >= 0")
   }
   if(any(rtss_cost_per_dose < 0) | any(rtss_consumables_cost < 0) | any(rtss_delivery_cost < 0)){
     stop("RTSS cost inputs must be >= 0")
   }
-  rtss_cost_per_dose_delivered <- rtss_cost_per_dose + rtss_consumables_cost + rtss_delivery_cost
-  cost <- n_doses * rtss_cost_per_dose_delivered
+  unit_cost <- rtss_cost_per_dose + rtss_consumables_cost + rtss_delivery_cost
+  unit_cost <- inflation_adjust(unit_cost, input_year, ...)
+  cost <- n_doses * unit_cost
   return(cost)
 }
 
@@ -73,6 +79,8 @@ cost_rtss <- function(n_doses, rtss_cost_per_dose = 10.02, rtss_consumables_cost
 #' @param r21_cost_per_dose Cost per R21 dose
 #' @param r21_consumables_cost Cost for consumables for one dose (e.g injection and reconstitution syringes, safety box etc.)
 #' @param r21_delivery_cost Cost for delivery of one dose
+#' @param input_year Year the unit costs are reported in
+#' @param ... Additional arguments passed to `inflation_adjust()`
 #'
 #' @return R21 costs
 #' @export
@@ -100,14 +108,17 @@ cost_rtss <- function(n_doses, rtss_cost_per_dose = 10.02, rtss_consumables_cost
 #' Age-based: $1.48 (default)
 #' Seasonal: $3.75
 #' Hybrid: $2.36
-cost_r21 <- function(n_doses, r21_cost_per_dose = 4, r21_consumables_cost = 1.52, r21_delivery_cost = 1.48){
+cost_r21 <- function(n_doses, r21_cost_per_dose = 4, r21_consumables_cost = 1.52,
+                     r21_delivery_cost = 1.48, input_year = 1999,
+                     ...){
   if(any(n_doses < 0)){
     stop("All n_doses estimates must be >= 0")
   }
   if(any(r21_cost_per_dose < 0) | any(r21_consumables_cost < 0) | any(r21_delivery_cost < 0)){
     stop("R21 cost inputs must be >= 0")
   }
-  r21_cost_per_dose_delivered <- r21_cost_per_dose + r21_consumables_cost + r21_delivery_cost
-  cost <- n_doses * r21_cost_per_dose_delivered
+  unit_cost <- r21_cost_per_dose + r21_consumables_cost + r21_delivery_cost
+  unit_cost <- inflation_adjust(unit_cost, input_year, ...)
+  cost <- n_doses * unit_cost
   return(cost)
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,10 @@
+.onLoad <- function(libname, pkgname) {
+  op <- options()
+  op.treasure <- list(
+    treasure.target_year = 2024,
+    treasure.region = "Sub-Saharan Africa"
+  )
+  toset <- !(names(op.treasure) %in% names(op))
+  if (any(toset)) options(op.treasure[toset])
+  invisible()
+}

--- a/tests/testthat/test-acd.R
+++ b/tests/testthat/test-acd.R
@@ -1,20 +1,28 @@
 test_that("pACD works", {
-  expect_equal(cost_pacd(n_tested = 1), 1 * 4.79)
-  expect_equal(cost_pacd(n_tested = 2), 2 * 4.79)
-  expect_equal(cost_pacd(n_tested = c(1, 2)), c(1, 2) * 4.79)
+  unit <- inflation_adjust(4.79, 1999, 2024)
+  expect_equal(cost_pacd(n_tested = 1), 1 * unit)
+  expect_equal(cost_pacd(n_tested = 2), 2 * unit)
+  expect_equal(cost_pacd(n_tested = c(1, 2)), c(1, 2) * unit)
 
-  expect_equal(cost_pacd(n_tested = 1, cost_per_person_tested  = 2), 1 * 2)
+  expect_equal(
+    cost_pacd(n_tested = 1, cost_per_person_tested  = 2, target_year = 2024),
+    1 * inflation_adjust(2, 1999, 2024)
+  )
 
   expect_error(cost_pacd(n_tested = -1), "All n_tested estimates must be >= 0")
   expect_error(cost_pacd(n_tested = 1, cost_per_person_tested = -1), "pACD cost inputs must be >= 0")
 })
 
 test_that("rACD works", {
-  expect_equal(cost_racd(n_tested = 1), 1 * 38.63)
-  expect_equal(cost_racd(n_tested = 2), 2 * 38.63)
-  expect_equal(cost_racd(n_tested = c(1, 2)), c(1, 2) * 38.63)
+  unit <- inflation_adjust(38.63, 1999, 2024)
+  expect_equal(cost_racd(n_tested = 1), 1 * unit)
+  expect_equal(cost_racd(n_tested = 2), 2 * unit)
+  expect_equal(cost_racd(n_tested = c(1, 2)), c(1, 2) * unit)
 
-  expect_equal(cost_racd(n_tested = 1, cost_per_person_tested  = 2), 1 * 2)
+  expect_equal(
+    cost_racd(n_tested = 1, cost_per_person_tested  = 2, target_year = 2024),
+    1 * inflation_adjust(2, 1999, 2024)
+  )
 
   expect_error(cost_racd(n_tested = -1), "All n_tested estimates must be >= 0")
   expect_error(cost_racd(n_tested = 1, cost_per_person_tested = -1), "rACD cost inputs must be >= 0")

--- a/tests/testthat/test-bed-nets.R
+++ b/tests/testthat/test-bed-nets.R
@@ -1,21 +1,37 @@
 test_that("LLIN costing", {
-  expect_equal(cost_llin(n_llin = 1), 1 * (2.02 + 1.50))
-  expect_equal(cost_llin(n_llin = 2), 2 * (2.02 + 1.50))
-  expect_equal(cost_llin(n_llin = c(1, 2)), c(1, 2) * (2.02 + 1.50))
+  unit <- inflation_adjust(2.02 + 1.50, 1999, 2024)
+  expect_equal(cost_llin(n_llin = 1), 1 * unit)
+  expect_equal(cost_llin(n_llin = 2), 2 * unit)
+  expect_equal(cost_llin(n_llin = c(1, 2)), c(1, 2) * unit)
 
-  expect_equal(cost_llin(n_llin = 1, llin_unit_cost  = 2, llin_delivery_cost  = 3), 1 * (2 + 3))
+  expect_equal(
+    cost_llin(n_llin = 1, llin_unit_cost  = 2, llin_delivery_cost  = 3,
+              target_year = 2024),
+    1 * inflation_adjust(2 + 3, 1999, 2024)
+  )
 
   expect_error(cost_llin(n_llin = -1), "All llin_n estimates must be >= 0")
   expect_error(cost_llin(n_llin = 1, llin_unit_cost = -1), "LLIN cost inputs must be >= 0")
   expect_error(cost_llin(n_llin = 1, llin_delivery_cost = -1), "LLIN cost inputs must be >= 0")
 })
 
-test_that("Pyrethroid-PBO costing", {
-  expect_equal(cost_pbo_itn(n_pbo_itn = 1), 1 * (2.63 + 1.50))
-  expect_equal(cost_pbo_itn(n_pbo_itn = 2), 2 * (2.63 + 1.50))
-  expect_equal(cost_pbo_itn(n_pbo_itn = c(1, 2)), c(1, 2) * (2.63 + 1.50))
+test_that("LLIN costing uses global region", {
+  options(treasure.region = "South Asia")
+  unit <- inflation_adjust(2.02 + 1.50, 1999, 2024, region = "South Asia")
+  expect_equal(cost_llin(n_llin = 1, target_year = 2024), 1 * unit)
+})
 
-  expect_equal(cost_pbo_itn(n_pbo_itn = 1, pbo_itn_unit_cost = 2, pbo_itn_delivery_cost  = 3), 1 * (2 + 3))
+test_that("Pyrethroid-PBO costing", {
+  unit <- inflation_adjust(2.63 + 1.50, 1999, 2024)
+  expect_equal(cost_pbo_itn(n_pbo_itn = 1), 1 * unit)
+  expect_equal(cost_pbo_itn(n_pbo_itn = 2), 2 * unit)
+  expect_equal(cost_pbo_itn(n_pbo_itn = c(1, 2)), c(1, 2) * unit)
+
+  expect_equal(
+    cost_pbo_itn(n_pbo_itn = 1, pbo_itn_unit_cost = 2,
+                 pbo_itn_delivery_cost  = 3, target_year = 2024),
+    1 * inflation_adjust(2 + 3, 1999, 2024)
+  )
 
   expect_error(cost_pbo_itn(n_pbo_itn = -1), "All llin_n estimates must be >= 0")
   expect_error(cost_pbo_itn(n_pbo_itn = 1, pbo_itn_unit_cost = -1), "PBO cost inputs must be >= 0")
@@ -23,11 +39,16 @@ test_that("Pyrethroid-PBO costing", {
 })
 
 test_that("Pyrethroid-chlorfenapyr costing", {
-  expect_equal(cost_dualai_itn(n_dualai_itn = 1), 1 * (2.70 + 1.50))
-  expect_equal(cost_dualai_itn(n_dualai_itn = 2), 2 * (2.70 + 1.50))
-  expect_equal(cost_dualai_itn(n_dualai_itn = c(1, 2)), c(1, 2) * (2.70 + 1.50))
+  unit <- inflation_adjust(2.70 + 1.50, 1999, 2024)
+  expect_equal(cost_dualai_itn(n_dualai_itn = 1), 1 * unit)
+  expect_equal(cost_dualai_itn(n_dualai_itn = 2), 2 * unit)
+  expect_equal(cost_dualai_itn(n_dualai_itn = c(1, 2)), c(1, 2) * unit)
 
-  expect_equal(cost_dualai_itn(n_dualai_itn = 1, dualai_itn_unit_cost = 2, dualai_itn_delivery_cost  = 3), 1 * (2 + 3))
+  expect_equal(
+    cost_dualai_itn(n_dualai_itn = 1, dualai_itn_unit_cost = 2,
+                    dualai_itn_delivery_cost  = 3, target_year = 2024),
+    1 * inflation_adjust(2 + 3, 1999, 2024)
+  )
 
   expect_error(cost_dualai_itn(n_dualai_itn = -1), "All llin_n estimates must be >= 0")
   expect_error(cost_dualai_itn(n_dualai_itn = 1, dualai_itn_unit_cost = -1), "Dual ai cost inputs must be >= 0")

--- a/tests/testthat/test-dx_tx.R
+++ b/tests/testthat/test-dx_tx.R
@@ -1,10 +1,17 @@
 test_that("RDT costing", {
-  expect_equal(cost_rdt(n_tests = 1), 1 * (0.46 * 1.15))
-  expect_equal(cost_rdt(n_tests = 2), 2 * (0.46 * 1.15))
-  expect_equal(cost_rdt(n_tests = c(1, 2)), c(1, 2) * (0.46 * 1.15))
+  unit <- inflation_adjust(0.46 + (0.46 * 0.15), 1999, 2024)
+  expect_equal(cost_rdt(n_tests = 1), 1 * unit)
+  expect_equal(cost_rdt(n_tests = 2), 2 * unit)
+  expect_equal(cost_rdt(n_tests = c(1, 2)), c(1, 2) * unit)
 
-  expect_equal(cost_rdt(n_tests = 1, rdt_unit_cost  = 2), 1 * (2 * 1.15))
-  expect_equal(cost_rdt(n_tests = 1, delivery_mark_up  = 0.5), 1 * (0.46 * 1.5))
+  expect_equal(
+    cost_rdt(n_tests = 1, rdt_unit_cost  = 2, target_year = 2024),
+    1 * inflation_adjust(2 + (2 * 0.15), 1999, 2024)
+  )
+  expect_equal(
+    cost_rdt(n_tests = 1, delivery_mark_up  = 0.5, target_year = 2024),
+    1 * inflation_adjust(0.46 + (0.46 * 0.5), 1999, 2024)
+  )
 
   expect_error(cost_rdt(n_tests = -1), "All n_tests estimates must be >= 0")
   expect_error(cost_rdt(n_tests = 1, rdt_unit_cost = -1), "RDT cost inputs must be >= 0")
@@ -12,44 +19,60 @@ test_that("RDT costing", {
 })
 
 test_that("Microscopy costing", {
-  expect_equal(cost_microscopy(n_tests = 1), 1 * 0.67)
-  expect_equal(cost_microscopy(n_tests = 2), 2 * 0.67)
-  expect_equal(cost_microscopy(n_tests = c(1, 2)), c(1, 2) * 0.67)
+  unit <- inflation_adjust(0.67, 1999, 2024)
+  expect_equal(cost_microscopy(n_tests = 1), 1 * unit)
+  expect_equal(cost_microscopy(n_tests = 2), 2 * unit)
+  expect_equal(cost_microscopy(n_tests = c(1, 2)), c(1, 2) * unit)
 
-  expect_equal(cost_microscopy(n_tests = 1, cost_per_slide = 2), 1 * 2)
+  expect_equal(
+    cost_microscopy(n_tests = 1, cost_per_slide = 2, target_year = 2024),
+    1 * inflation_adjust(2, 1999, 2024)
+  )
 
   expect_error(cost_microscopy(n_tests = -1), "All n_tests estimates must be >= 0")
   expect_error(cost_microscopy(n_tests = 1, cost_per_slide = -1), "Microscopy cost inputs must be >= 0")
 })
 
 test_that("AL costing", {
-  expect_equal(cost_al(n_doses = 1), 1 * 0.3)
-  expect_equal(cost_al(n_doses = 2), 2 * 0.3)
-  expect_equal(cost_al(n_doses = c(1, 2)), c(1, 2) * 0.3)
+  unit <- inflation_adjust(0.3, 1999, 2024)
+  expect_equal(cost_al(n_doses = 1), 1 * unit)
+  expect_equal(cost_al(n_doses = 2), 2 * unit)
+  expect_equal(cost_al(n_doses = c(1, 2)), c(1, 2) * unit)
 
-  expect_equal(cost_al(n_doses = 1, cost_per_dose  = 2), 1 * 2)
+  expect_equal(
+    cost_al(n_doses = 1, cost_per_dose  = 2, target_year = 2024),
+    1 * inflation_adjust(2, 1999, 2024)
+  )
 
   expect_error(cost_al(n_doses = -1), "All n_doses estimates must be >= 0")
   expect_error(cost_al(n_doses = 1, cost_per_dose = -1), "AL cost inputs must be >= 0")
 })
 
 test_that("Chloroquine costing", {
-  expect_equal(cost_chloroquine(n_doses = 1), 1 * (0.10 / 10))
-  expect_equal(cost_chloroquine(n_doses = 2), 2 * (0.10 / 10))
-  expect_equal(cost_chloroquine(n_doses = c(1, 2)), c(1, 2) * (0.10 / 10))
+  unit <- inflation_adjust(0.10 / 10, 1999, 2024)
+  expect_equal(cost_chloroquine(n_doses = 1), 1 * unit)
+  expect_equal(cost_chloroquine(n_doses = 2), 2 * unit)
+  expect_equal(cost_chloroquine(n_doses = c(1, 2)), c(1, 2) * unit)
 
-  expect_equal(cost_chloroquine(n_doses = 1, cost_per_dose = 2), 1 * 2)
+  expect_equal(
+    cost_chloroquine(n_doses = 1, cost_per_dose = 2, target_year = 2024),
+    1 * inflation_adjust(2, 1999, 2024)
+  )
 
   expect_error(cost_chloroquine(n_doses = -1), "All n_doses estimates must be >= 0")
   expect_error(cost_chloroquine(n_doses = 1, cost_per_dose = -1), "Chloroquine cost inputs must be >= 0")
 })
 
 test_that("Primaquine costing", {
-  expect_equal(cost_primaquine(n_doses = 1), 1 * 0.4)
-  expect_equal(cost_primaquine(n_doses = 2), 2 * 0.4)
-  expect_equal(cost_primaquine(n_doses = c(1, 2)), c(1, 2) * 0.4)
+  unit <- inflation_adjust(0.4, 1999, 2024)
+  expect_equal(cost_primaquine(n_doses = 1), 1 * unit)
+  expect_equal(cost_primaquine(n_doses = 2), 2 * unit)
+  expect_equal(cost_primaquine(n_doses = c(1, 2)), c(1, 2) * unit)
 
-  expect_equal(cost_primaquine(n_doses = 1, cost_per_dose  = 2), 1 * 2)
+  expect_equal(
+    cost_primaquine(n_doses = 1, cost_per_dose  = 2, target_year = 2024),
+    1 * inflation_adjust(2, 1999, 2024)
+  )
 
   expect_error(cost_primaquine(n_doses = -1), "All n_doses estimates must be >= 0")
   expect_error(cost_primaquine(n_doses = 1, cost_per_dose = -1), "Primaquine cost inputs must be >= 0")
@@ -57,22 +80,33 @@ test_that("Primaquine costing", {
 
 test_that("WHO CHOICE costing", {
   # Outpatient
-  expect_equal(cost_outpatient(n_visits = 1, cost_per_visit = 1), 1 * 1)
-  expect_equal(cost_outpatient(n_visits = 2, cost_per_visit = 1), 2 * 1)
-  expect_equal(cost_outpatient(n_visits = c(1, 2), cost_per_visit = 1), c(1, 2) * 1)
+  unit_out <- inflation_adjust(1, 1999, 2024)
+  expect_equal(cost_outpatient(n_visits = 1, cost_per_visit = 1), 1 * unit_out)
+  expect_equal(cost_outpatient(n_visits = 2, cost_per_visit = 1), 2 * unit_out)
+  expect_equal(cost_outpatient(n_visits = c(1, 2), cost_per_visit = 1), c(1, 2) * unit_out)
 
-  expect_equal(cost_outpatient(n_visits = 1, cost_per_visit = 2), 1 * 2)
+  expect_equal(
+    cost_outpatient(n_visits = 1, cost_per_visit = 2, target_year = 2024),
+    1 * inflation_adjust(2, 1999, 2024)
+  )
 
   expect_error(cost_outpatient(n_visits = -1, cost_per_visit = 1), "All n_visits estimates must be >= 0")
   expect_error(cost_outpatient(n_visits = 1, cost_per_visit = -1), "Outpatient cost inputs must be >= 0")
 
   # Inpatient
-  expect_equal(cost_inpatient(n_visits = 1, cost_per_day = 1), 1 * 1 * 3)
-  expect_equal(cost_inpatient(n_visits = 1, cost_per_day = 1, average_stay_duration = 4), 1 * 1 * 4)
-  expect_equal(cost_inpatient(n_visits = 2, cost_per_day = 1), 2 * 1 * 3)
-  expect_equal(cost_inpatient(n_visits = c(1, 2), cost_per_day = 1), c(1, 2) * 1 * 3)
+  unit_in <- inflation_adjust(1, 1999, 2024)
+  expect_equal(cost_inpatient(n_visits = 1, cost_per_day = 1), 1 * unit_in * 3)
+  expect_equal(
+    cost_inpatient(n_visits = 1, cost_per_day = 1, average_stay_duration = 4),
+    1 * unit_in * 4
+  )
+  expect_equal(cost_inpatient(n_visits = 2, cost_per_day = 1), 2 * unit_in * 3)
+  expect_equal(cost_inpatient(n_visits = c(1, 2), cost_per_day = 1), c(1, 2) * unit_in * 3)
 
-  expect_equal(cost_inpatient(n_visits = 1, cost_per_day = 2), 1 * 2 * 3)
+  expect_equal(
+    cost_inpatient(n_visits = 1, cost_per_day = 2, target_year = 2024),
+    1 * inflation_adjust(2, 1999, 2024) * 3
+  )
 
   expect_error(cost_inpatient(n_visits = -1, cost_per_day = 1), "All n_visits estimates must be >= 0")
   expect_error(cost_inpatient(n_visits = 1, cost_per_day = -1), "Inpatient cost inputs must be >= 0")

--- a/tests/testthat/test-inflate.R
+++ b/tests/testthat/test-inflate.R
@@ -5,8 +5,35 @@ test_that("inflation adjustment uses CPI ratios", {
   expect_equal(inflation_adjust(0.26, 2007, 2024), 0.26 * (target / base))
 })
 
+test_that("inflation adjustment uses global option when target_year missing", {
+  options(treasure.target_year = 2024)
+  cpi_region <- cpi[cpi$region == "Sub-Saharan Africa", ]
+  base <- cpi_region$cpi[cpi_region$year == 2007]
+  target <- cpi_region$cpi[cpi_region$year == 2024]
+  expect_equal(inflation_adjust(0.26, 2007), 0.26 * (target / base))
+})
+
+test_that("inflation adjustment uses global option when region missing", {
+  options(treasure.region = "South Asia")
+  cpi_region <- cpi[cpi$region == "South Asia", ]
+  base <- cpi_region$cpi[cpi_region$year == 2007]
+  target <- cpi_region$cpi[cpi_region$year == 2024]
+  expect_equal(inflation_adjust(0.26, 2007, 2024),
+               0.26 * (target / base))
+})
+
 test_that("inflation adjustment input validation", {
   expect_error(inflation_adjust(1, 1900, 2024), "cost_year not found")
   expect_error(inflation_adjust(1, 2007, 3000), "target_year not found")
-  expect_error(inflation_adjust(c(1,2), 2007, 2024), "single values")
+})
+
+test_that("inflation adjustment vectorises", {
+  cpi_region <- cpi[cpi$region == "Sub-Saharan Africa", ]
+  base1 <- cpi_region$cpi[cpi_region$year == 2007]
+  base2 <- cpi_region$cpi[cpi_region$year == 2008]
+  target <- cpi_region$cpi[cpi_region$year == 2024]
+  expect_equal(
+    inflation_adjust(c(0.26, 0.52), c(2007, 2008), 2024),
+    c(0.26 * (target / base1), 0.52 * (target / base2))
+  )
 })

--- a/tests/testthat/test-iptp.R
+++ b/tests/testthat/test-iptp.R
@@ -1,9 +1,13 @@
 test_that("IPTp costing", {
-  expect_equal(cost_iptp(n_administrations = 1), 1 * 0.79)
-  expect_equal(cost_iptp(n_administrations = 2), 2 * 0.79)
-  expect_equal(cost_iptp(n_administrations = c(1, 2)), c(1, 2) * 0.79)
+  unit <- inflation_adjust(0.79, 1999, 2024)
+  expect_equal(cost_iptp(n_administrations = 1), 1 * unit)
+  expect_equal(cost_iptp(n_administrations = 2), 2 * unit)
+  expect_equal(cost_iptp(n_administrations = c(1, 2)), c(1, 2) * unit)
 
-  expect_equal(cost_iptp(n_administrations = 1, iptp_cost_per_administration  = 2), 1 * 2)
+  expect_equal(
+    cost_iptp(n_administrations = 1, iptp_cost_per_administration  = 2, target_year = 2024),
+    1 * inflation_adjust(2, 1999, 2024)
+  )
 
   expect_error(cost_iptp(n_administrations = -1), "All n_administrations estimates must be >= 0")
   expect_error(cost_iptp(n_administrations = 1, iptp_cost_per_administration = -1), "IPTp cost inputs must be >= 0")

--- a/tests/testthat/test-irs.R
+++ b/tests/testthat/test-irs.R
@@ -1,20 +1,28 @@
 test_that("IRS costing", {
   # Long lasting per person
-  expect_equal(cost_ll_irs_person(n_protected = 1), 1 * 7.44)
-  expect_equal(cost_ll_irs_person(n_protected = 2), 2 * 7.44)
-  expect_equal(cost_ll_irs_person(n_protected = c(1, 2)), c(1, 2) * 7.44)
+  unit_person <- inflation_adjust(7.44, 1999, 2024)
+  expect_equal(cost_ll_irs_person(n_protected = 1), 1 * unit_person)
+  expect_equal(cost_ll_irs_person(n_protected = 2), 2 * unit_person)
+  expect_equal(cost_ll_irs_person(n_protected = c(1, 2)), c(1, 2) * unit_person)
 
-  expect_equal(cost_ll_irs_person(n_protected = 1, cost_per_person_protected  = 2), 1 * 2)
+  expect_equal(
+    cost_ll_irs_person(n_protected = 1, cost_per_person_protected  = 2, target_year = 2024),
+    1 * inflation_adjust(2, 1999, 2024)
+  )
 
   expect_error(cost_ll_irs_person(n_protected = -1), "All n_protected estimates must be >= 0")
   expect_error(cost_ll_irs_person(n_protected = 1, cost_per_person_protected = -1), "Long lasting IRS cost inputs must be >= 0")
 
   # Long lasting per structure
-  expect_equal(cost_ll_irs_structure(n_sprayed = 1), 1 * 26.36)
-  expect_equal(cost_ll_irs_structure(n_sprayed = 2), 2 * 26.36)
-  expect_equal(cost_ll_irs_structure(n_sprayed = c(1, 2)), c(1, 2) * 26.36)
+  unit_struct <- inflation_adjust(26.36, 1999, 2024)
+  expect_equal(cost_ll_irs_structure(n_sprayed = 1), 1 * unit_struct)
+  expect_equal(cost_ll_irs_structure(n_sprayed = 2), 2 * unit_struct)
+  expect_equal(cost_ll_irs_structure(n_sprayed = c(1, 2)), c(1, 2) * unit_struct)
 
-  expect_equal(cost_ll_irs_structure(n_sprayed = 1, cost_per_structure_sprayed  = 2), 1 * 2)
+  expect_equal(
+    cost_ll_irs_structure(n_sprayed = 1, cost_per_structure_sprayed  = 2, target_year = 2024),
+    1 * inflation_adjust(2, 1999, 2024)
+  )
 
   expect_error(cost_ll_irs_structure(n_sprayed = -1), "All n_sprayed estimates must be >= 0")
   expect_error(cost_ll_irs_structure(n_sprayed = 1, cost_per_structure_sprayed = -1), "Long lasting IRS cost inputs must be >= 0")

--- a/tests/testthat/test-pmc.R
+++ b/tests/testthat/test-pmc.R
@@ -1,9 +1,13 @@
 test_that("PMC costing", {
-  expect_equal(cost_pmc(n_doses = 1), 1 * 0.3894)
-  expect_equal(cost_pmc(n_doses = 2), 2 * 0.3894)
-  expect_equal(cost_pmc(n_doses = c(1, 2)), c(1, 2) * 0.3894)
+  unit <- inflation_adjust(0.3894, 1999, 2024)
+  expect_equal(cost_pmc(n_doses = 1), 1 * unit)
+  expect_equal(cost_pmc(n_doses = 2), 2 * unit)
+  expect_equal(cost_pmc(n_doses = c(1, 2)), c(1, 2) * unit)
 
-  expect_equal(cost_pmc(n_doses = 1, pmc_cost_per_dose_delivered  = 2), 1 * 2)
+  expect_equal(
+    cost_pmc(n_doses = 1, pmc_cost_per_dose_delivered  = 2, target_year = 2024),
+    1 * inflation_adjust(2, 1999, 2024)
+  )
 
   expect_error(cost_pmc(n_doses = -1), "All n_doses estimates must be >= 0")
   expect_error(cost_pmc(n_doses = 1, pmc_cost_per_dose_delivered = -1), "PMC cost inputs must be >= 0")

--- a/tests/testthat/test-smc.R
+++ b/tests/testthat/test-smc.R
@@ -1,9 +1,13 @@
 test_that("SMC costing", {
-  expect_equal(cost_smc(n_doses = 1), 1 * 0.9075)
-  expect_equal(cost_smc(n_doses = 2), 2 * 0.9075)
-  expect_equal(cost_smc(n_doses = c(1, 2)), c(1, 2) * 0.9075)
+  unit <- inflation_adjust(0.9075, 1999, 2024)
+  expect_equal(cost_smc(n_doses = 1), 1 * unit)
+  expect_equal(cost_smc(n_doses = 2), 2 * unit)
+  expect_equal(cost_smc(n_doses = c(1, 2)), c(1, 2) * unit)
 
-  expect_equal(cost_smc(n_doses = 1, smc_cost_per_dose_delivered  = 2), 1 * 2)
+  expect_equal(
+    cost_smc(n_doses = 1, smc_cost_per_dose_delivered  = 2, target_year = 2024),
+    1 * inflation_adjust(2, 1999, 2024)
+  )
 
   expect_error(cost_smc(n_doses = -1), "All n_doses estimates must be >= 0")
   expect_error(cost_smc(n_doses = 1, smc_cost_per_dose_delivered = -1), "SMC cost inputs must be >= 0")

--- a/tests/testthat/test-surveillance.R
+++ b/tests/testthat/test-surveillance.R
@@ -1,9 +1,13 @@
 test_that("multiplication works", {
-  expect_equal(cost_surveillance(pop_at_risk = 1), 1 * 0.05)
-  expect_equal(cost_surveillance(pop_at_risk = 2), 2 * 0.05)
-  expect_equal(cost_surveillance(pop_at_risk = c(1, 2)), c(1, 2) * 0.05)
+  unit <- inflation_adjust(0.05, 1999, 2024)
+  expect_equal(cost_surveillance(pop_at_risk = 1), 1 * unit)
+  expect_equal(cost_surveillance(pop_at_risk = 2), 2 * unit)
+  expect_equal(cost_surveillance(pop_at_risk = c(1, 2)), c(1, 2) * unit)
 
-  expect_equal(cost_surveillance(pop_at_risk = 1, cost_per_pop_at_risk  = 2), 1 * 2)
+  expect_equal(
+    cost_surveillance(pop_at_risk = 1, cost_per_pop_at_risk  = 2, target_year = 2024),
+    1 * inflation_adjust(2, 1999, 2024)
+  )
 
   expect_error(cost_surveillance(pop_at_risk = -1), "All pop_at_risk estimates must be >= 0")
   expect_error(cost_surveillance(pop_at_risk = 1, cost_per_pop_at_risk = -1), "Surveillance cost inputs must be >= 0")

--- a/tests/testthat/test-vaccine.R
+++ b/tests/testthat/test-vaccine.R
@@ -1,11 +1,15 @@
 test_that("RTSS costing", {
-  expect_equal(cost_rtss(n_doses = 1), 1 * (10.02 + 1.52 + 1.48))
-  expect_equal(cost_rtss(n_doses = 2), 2 * (10.02 + 1.52 + 1.48))
-  expect_equal(cost_rtss(n_doses = c(1, 2)), c(1, 2) * (10.02 + 1.52 + 1.48))
+  unit <- inflation_adjust(10.02 + 1.52 + 1.48, 1999, 2024)
+  expect_equal(cost_rtss(n_doses = 1), 1 * unit)
+  expect_equal(cost_rtss(n_doses = 2), 2 * unit)
+  expect_equal(cost_rtss(n_doses = c(1, 2)), c(1, 2) * unit)
 
-  expect_equal(cost_rtss(n_doses = 1, rtss_cost_per_dose  = 2,
-                         rtss_consumables_cost  = 3, rtss_delivery_cost = 4),
-               1 * (2 + 3 + 4))
+  expect_equal(
+    cost_rtss(n_doses = 1, rtss_cost_per_dose  = 2,
+               rtss_consumables_cost  = 3, rtss_delivery_cost = 4,
+               target_year = 2024),
+    1 * inflation_adjust(2 + 3 + 4, 1999, 2024)
+  )
 
   expect_error(cost_rtss(n_doses = -1), "All n_doses estimates must be >= 0")
   expect_error(cost_rtss(n_doses = 1, rtss_cost_per_dose = -1), "RTSS cost inputs must be >= 0")
@@ -14,13 +18,17 @@ test_that("RTSS costing", {
 })
 
 test_that("R21 costing", {
-  expect_equal(cost_r21(n_doses = 1), 1 * (4 + 1.52 + 1.48))
-  expect_equal(cost_r21(n_doses = 2), 2 * (4 + 1.52 + 1.48))
-  expect_equal(cost_r21(n_doses = c(1, 2)), c(1, 2) * (4 + 1.52 + 1.48))
+  unit <- inflation_adjust(4 + 1.52 + 1.48, 1999, 2024)
+  expect_equal(cost_r21(n_doses = 1), 1 * unit)
+  expect_equal(cost_r21(n_doses = 2), 2 * unit)
+  expect_equal(cost_r21(n_doses = c(1, 2)), c(1, 2) * unit)
 
-  expect_equal(cost_r21(n_doses = 1, r21_cost_per_dose  = 2,
-                        r21_consumables_cost  = 3, r21_delivery_cost = 4),
-               1 * (2 + 3 + 4))
+  expect_equal(
+    cost_r21(n_doses = 1, r21_cost_per_dose  = 2,
+              r21_consumables_cost  = 3, r21_delivery_cost = 4,
+              target_year = 2024),
+    1 * inflation_adjust(2 + 3 + 4, 1999, 2024)
+  )
 
   expect_error(cost_r21(n_doses = -1), "All n_doses estimates must be >= 0")
   expect_error(cost_r21(n_doses = 1, r21_cost_per_dose = -1), "R21 cost inputs must be >= 0")


### PR DESCRIPTION
## Summary
- make `inflation_adjust()` vectorised and pull defaults from options
- pass `...` from all `cost_*` functions to `inflation_adjust`
- update tests for new inflation behaviour
- document ellipsis arguments in cost function docs

## Testing
- `devtools::test()` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684ff53be7308326a2058ace4f2c2f29