### PR TITLE
Update costing tests

### DIFF
--- a/tests/testthat/test-acd.R
+++ b/tests/testthat/test-acd.R
@@ -1,12 +1,12 @@
 test_that("pACD works", {
-  unit <- inflation_adjust(4.79, 1999, 2024)
+  unit <- inflation_adjust(4.79, 2015, 2024)
   expect_equal(cost_pacd(n_tested = 1), 1 * unit)
   expect_equal(cost_pacd(n_tested = 2), 2 * unit)
   expect_equal(cost_pacd(n_tested = c(1, 2)), c(1, 2) * unit)
 
   expect_equal(
     cost_pacd(n_tested = 1, cost_per_person_tested  = 2, target_year = 2024),
-    1 * inflation_adjust(2, 1999, 2024)
+    1 * inflation_adjust(2, 2015, 2024)
   )
 
   expect_error(cost_pacd(n_tested = -1), "All n_tested estimates must be >= 0")
@@ -14,14 +14,14 @@ test_that("pACD works", {
 })
 
 test_that("rACD works", {
-  unit <- inflation_adjust(38.63, 1999, 2024)
+  unit <- inflation_adjust(38.63, 2016, 2024)
   expect_equal(cost_racd(n_tested = 1), 1 * unit)
   expect_equal(cost_racd(n_tested = 2), 2 * unit)
   expect_equal(cost_racd(n_tested = c(1, 2)), c(1, 2) * unit)
 
   expect_equal(
     cost_racd(n_tested = 1, cost_per_person_tested  = 2, target_year = 2024),
-    1 * inflation_adjust(2, 1999, 2024)
+    1 * inflation_adjust(2, 2016, 2024)
   )
 
   expect_error(cost_racd(n_tested = -1), "All n_tested estimates must be >= 0")

--- a/tests/testthat/test-bed-nets.R
+++ b/tests/testthat/test-bed-nets.R
@@ -1,5 +1,5 @@
 test_that("LLIN costing", {
-  unit <- inflation_adjust(2.02 + 1.50, 1999, 2024)
+  unit <- inflation_adjust(2.02 + 1.50, 2024, 2024)
   expect_equal(cost_llin(n_llin = 1), 1 * unit)
   expect_equal(cost_llin(n_llin = 2), 2 * unit)
   expect_equal(cost_llin(n_llin = c(1, 2)), c(1, 2) * unit)
@@ -7,7 +7,7 @@ test_that("LLIN costing", {
   expect_equal(
     cost_llin(n_llin = 1, llin_unit_cost  = 2, llin_delivery_cost  = 3,
               target_year = 2024),
-    1 * inflation_adjust(2 + 3, 1999, 2024)
+    1 * inflation_adjust(2 + 3, 2024, 2024)
   )
 
   expect_error(cost_llin(n_llin = -1), "All llin_n estimates must be >= 0")
@@ -16,13 +16,13 @@ test_that("LLIN costing", {
 })
 
 test_that("LLIN costing uses global region", {
-  options(treasure.region = "South Asia")
-  unit <- inflation_adjust(2.02 + 1.50, 1999, 2024, region = "South Asia")
+  set_region("South Asia")
+  unit <- inflation_adjust(2.02 + 1.50, 2024, 2024, region = "South Asia")
   expect_equal(cost_llin(n_llin = 1, target_year = 2024), 1 * unit)
 })
 
 test_that("Pyrethroid-PBO costing", {
-  unit <- inflation_adjust(2.63 + 1.50, 1999, 2024)
+  unit <- inflation_adjust(2.63 + 1.50, 2024, 2024)
   expect_equal(cost_pbo_itn(n_pbo_itn = 1), 1 * unit)
   expect_equal(cost_pbo_itn(n_pbo_itn = 2), 2 * unit)
   expect_equal(cost_pbo_itn(n_pbo_itn = c(1, 2)), c(1, 2) * unit)
@@ -30,7 +30,7 @@ test_that("Pyrethroid-PBO costing", {
   expect_equal(
     cost_pbo_itn(n_pbo_itn = 1, pbo_itn_unit_cost = 2,
                  pbo_itn_delivery_cost  = 3, target_year = 2024),
-    1 * inflation_adjust(2 + 3, 1999, 2024)
+    1 * inflation_adjust(2 + 3, 2024, 2024)
   )
 
   expect_error(cost_pbo_itn(n_pbo_itn = -1), "All llin_n estimates must be >= 0")
@@ -39,7 +39,7 @@ test_that("Pyrethroid-PBO costing", {
 })
 
 test_that("Pyrethroid-chlorfenapyr costing", {
-  unit <- inflation_adjust(2.70 + 1.50, 1999, 2024)
+  unit <- inflation_adjust(2.70 + 1.50, 2024, 2024)
   expect_equal(cost_dualai_itn(n_dualai_itn = 1), 1 * unit)
   expect_equal(cost_dualai_itn(n_dualai_itn = 2), 2 * unit)
   expect_equal(cost_dualai_itn(n_dualai_itn = c(1, 2)), c(1, 2) * unit)
@@ -47,7 +47,7 @@ test_that("Pyrethroid-chlorfenapyr costing", {
   expect_equal(
     cost_dualai_itn(n_dualai_itn = 1, dualai_itn_unit_cost = 2,
                     dualai_itn_delivery_cost  = 3, target_year = 2024),
-    1 * inflation_adjust(2 + 3, 1999, 2024)
+    1 * inflation_adjust(2 + 3, 2024, 2024)
   )
 
   expect_error(cost_dualai_itn(n_dualai_itn = -1), "All llin_n estimates must be >= 0")

--- a/tests/testthat/test-dx_tx.R
+++ b/tests/testthat/test-dx_tx.R
@@ -1,16 +1,16 @@
 test_that("RDT costing", {
-  unit <- inflation_adjust(0.46 + (0.46 * 0.15), 1999, 2024)
+  unit <- inflation_adjust(0.46 + (0.46 * 0.15), 2022, 2024)
   expect_equal(cost_rdt(n_tests = 1), 1 * unit)
   expect_equal(cost_rdt(n_tests = 2), 2 * unit)
   expect_equal(cost_rdt(n_tests = c(1, 2)), c(1, 2) * unit)
 
   expect_equal(
     cost_rdt(n_tests = 1, rdt_unit_cost  = 2, target_year = 2024),
-    1 * inflation_adjust(2 + (2 * 0.15), 1999, 2024)
+    1 * inflation_adjust(2 + (2 * 0.15), 2022, 2024)
   )
   expect_equal(
     cost_rdt(n_tests = 1, delivery_mark_up  = 0.5, target_year = 2024),
-    1 * inflation_adjust(0.46 + (0.46 * 0.5), 1999, 2024)
+    1 * inflation_adjust(0.46 + (0.46 * 0.5), 2022, 2024)
   )
 
   expect_error(cost_rdt(n_tests = -1), "All n_tests estimates must be >= 0")
@@ -19,14 +19,14 @@ test_that("RDT costing", {
 })
 
 test_that("Microscopy costing", {
-  unit <- inflation_adjust(0.67, 1999, 2024)
+  unit <- inflation_adjust(0.26, 2007, 2024)
   expect_equal(cost_microscopy(n_tests = 1), 1 * unit)
   expect_equal(cost_microscopy(n_tests = 2), 2 * unit)
   expect_equal(cost_microscopy(n_tests = c(1, 2)), c(1, 2) * unit)
 
   expect_equal(
     cost_microscopy(n_tests = 1, cost_per_slide = 2, target_year = 2024),
-    1 * inflation_adjust(2, 1999, 2024)
+    1 * inflation_adjust(2, 2007, 2024)
   )
 
   expect_error(cost_microscopy(n_tests = -1), "All n_tests estimates must be >= 0")
@@ -34,14 +34,14 @@ test_that("Microscopy costing", {
 })
 
 test_that("AL costing", {
-  unit <- inflation_adjust(0.3, 1999, 2024)
+  unit <- inflation_adjust(0.3, 2022, 2024)
   expect_equal(cost_al(n_doses = 1), 1 * unit)
   expect_equal(cost_al(n_doses = 2), 2 * unit)
   expect_equal(cost_al(n_doses = c(1, 2)), c(1, 2) * unit)
 
   expect_equal(
     cost_al(n_doses = 1, cost_per_dose  = 2, target_year = 2024),
-    1 * inflation_adjust(2, 1999, 2024)
+    1 * inflation_adjust(2, 2022, 2024)
   )
 
   expect_error(cost_al(n_doses = -1), "All n_doses estimates must be >= 0")
@@ -49,14 +49,14 @@ test_that("AL costing", {
 })
 
 test_that("Chloroquine costing", {
-  unit <- inflation_adjust(0.10 / 10, 1999, 2024)
+  unit <- inflation_adjust(0.10 / 10, 2003, 2024)
   expect_equal(cost_chloroquine(n_doses = 1), 1 * unit)
   expect_equal(cost_chloroquine(n_doses = 2), 2 * unit)
   expect_equal(cost_chloroquine(n_doses = c(1, 2)), c(1, 2) * unit)
 
   expect_equal(
     cost_chloroquine(n_doses = 1, cost_per_dose = 2, target_year = 2024),
-    1 * inflation_adjust(2, 1999, 2024)
+    1 * inflation_adjust(2, 2003, 2024)
   )
 
   expect_error(cost_chloroquine(n_doses = -1), "All n_doses estimates must be >= 0")
@@ -64,14 +64,14 @@ test_that("Chloroquine costing", {
 })
 
 test_that("Primaquine costing", {
-  unit <- inflation_adjust(0.4, 1999, 2024)
+  unit <- inflation_adjust(0.4, 2022, 2024)
   expect_equal(cost_primaquine(n_doses = 1), 1 * unit)
   expect_equal(cost_primaquine(n_doses = 2), 2 * unit)
   expect_equal(cost_primaquine(n_doses = c(1, 2)), c(1, 2) * unit)
 
   expect_equal(
     cost_primaquine(n_doses = 1, cost_per_dose  = 2, target_year = 2024),
-    1 * inflation_adjust(2, 1999, 2024)
+    1 * inflation_adjust(2, 2022, 2024)
   )
 
   expect_error(cost_primaquine(n_doses = -1), "All n_doses estimates must be >= 0")
@@ -80,21 +80,21 @@ test_that("Primaquine costing", {
 
 test_that("WHO CHOICE costing", {
   # Outpatient
-  unit_out <- inflation_adjust(1, 1999, 2024)
+  unit_out <- inflation_adjust(1, 2021, 2024)
   expect_equal(cost_outpatient(n_visits = 1, cost_per_visit = 1), 1 * unit_out)
   expect_equal(cost_outpatient(n_visits = 2, cost_per_visit = 1), 2 * unit_out)
   expect_equal(cost_outpatient(n_visits = c(1, 2), cost_per_visit = 1), c(1, 2) * unit_out)
 
   expect_equal(
     cost_outpatient(n_visits = 1, cost_per_visit = 2, target_year = 2024),
-    1 * inflation_adjust(2, 1999, 2024)
+    1 * inflation_adjust(2, 2021, 2024)
   )
 
   expect_error(cost_outpatient(n_visits = -1, cost_per_visit = 1), "All n_visits estimates must be >= 0")
   expect_error(cost_outpatient(n_visits = 1, cost_per_visit = -1), "Outpatient cost inputs must be >= 0")
 
   # Inpatient
-  unit_in <- inflation_adjust(1, 1999, 2024)
+  unit_in <- inflation_adjust(1, 2021, 2024)
   expect_equal(cost_inpatient(n_visits = 1, cost_per_day = 1), 1 * unit_in * 3)
   expect_equal(
     cost_inpatient(n_visits = 1, cost_per_day = 1, average_stay_duration = 4),
@@ -105,7 +105,7 @@ test_that("WHO CHOICE costing", {
 
   expect_equal(
     cost_inpatient(n_visits = 1, cost_per_day = 2, target_year = 2024),
-    1 * inflation_adjust(2, 1999, 2024) * 3
+    1 * inflation_adjust(2, 2021, 2024) * 3
   )
 
   expect_error(cost_inpatient(n_visits = -1, cost_per_day = 1), "All n_visits estimates must be >= 0")

--- a/tests/testthat/test-inflate.R
+++ b/tests/testthat/test-inflate.R
@@ -6,7 +6,7 @@ test_that("inflation adjustment uses CPI ratios", {
 })
 
 test_that("inflation adjustment uses global option when target_year missing", {
-  options(treasure.target_year = 2024)
+  set_target_year(2024)
   cpi_region <- cpi[cpi$region == "Sub-Saharan Africa", ]
   base <- cpi_region$cpi[cpi_region$year == 2007]
   target <- cpi_region$cpi[cpi_region$year == 2024]
@@ -14,7 +14,7 @@ test_that("inflation adjustment uses global option when target_year missing", {
 })
 
 test_that("inflation adjustment uses global option when region missing", {
-  options(treasure.region = "South Asia")
+  set_region("South Asia")
   cpi_region <- cpi[cpi$region == "South Asia", ]
   base <- cpi_region$cpi[cpi_region$year == 2007]
   target <- cpi_region$cpi[cpi_region$year == 2024]
@@ -22,9 +22,9 @@ test_that("inflation adjustment uses global option when region missing", {
                0.26 * (target / base))
 })
 
-test_that("inflation adjustment input validation", {
-  expect_error(inflation_adjust(1, 1900, 2024), "cost_year not found")
-  expect_error(inflation_adjust(1, 2007, 3000), "target_year not found")
+test_that("inflation adjustment handles missing years", {
+  expect_length(inflation_adjust(1, 1900, 2024), 0)
+  expect_length(inflation_adjust(1, 2007, 3000), 0)
 })
 
 test_that("inflation adjustment vectorises", {
@@ -36,4 +36,8 @@ test_that("inflation adjustment vectorises", {
     inflation_adjust(c(0.26, 0.52), c(2007, 2008), 2024),
     c(0.26 * (target / base1), 0.52 * (target / base2))
   )
+})
+
+test_that("inflation adjustment can be skipped", {
+  expect_equal(inflation_adjust(0.5, 2007, 2024, adjust = FALSE), 0.5)
 })

--- a/tests/testthat/test-iptp.R
+++ b/tests/testthat/test-iptp.R
@@ -1,12 +1,12 @@
 test_that("IPTp costing", {
-  unit <- inflation_adjust(0.79, 1999, 2024)
+  unit <- inflation_adjust(0.79, 2012, 2024)
   expect_equal(cost_iptp(n_administrations = 1), 1 * unit)
   expect_equal(cost_iptp(n_administrations = 2), 2 * unit)
   expect_equal(cost_iptp(n_administrations = c(1, 2)), c(1, 2) * unit)
 
   expect_equal(
     cost_iptp(n_administrations = 1, iptp_cost_per_administration  = 2, target_year = 2024),
-    1 * inflation_adjust(2, 1999, 2024)
+    1 * inflation_adjust(2, 2012, 2024)
   )
 
   expect_error(cost_iptp(n_administrations = -1), "All n_administrations estimates must be >= 0")

--- a/tests/testthat/test-irs.R
+++ b/tests/testthat/test-irs.R
@@ -1,27 +1,27 @@
 test_that("IRS costing", {
   # Long lasting per person
-  unit_person <- inflation_adjust(7.44, 1999, 2024)
+  unit_person <- inflation_adjust(7.44, 2020, 2024)
   expect_equal(cost_ll_irs_person(n_protected = 1), 1 * unit_person)
   expect_equal(cost_ll_irs_person(n_protected = 2), 2 * unit_person)
   expect_equal(cost_ll_irs_person(n_protected = c(1, 2)), c(1, 2) * unit_person)
 
   expect_equal(
     cost_ll_irs_person(n_protected = 1, cost_per_person_protected  = 2, target_year = 2024),
-    1 * inflation_adjust(2, 1999, 2024)
+    1 * inflation_adjust(2, 2020, 2024)
   )
 
   expect_error(cost_ll_irs_person(n_protected = -1), "All n_protected estimates must be >= 0")
   expect_error(cost_ll_irs_person(n_protected = 1, cost_per_person_protected = -1), "Long lasting IRS cost inputs must be >= 0")
 
   # Long lasting per structure
-  unit_struct <- inflation_adjust(26.36, 1999, 2024)
+  unit_struct <- inflation_adjust(26.36, 2020, 2024)
   expect_equal(cost_ll_irs_structure(n_sprayed = 1), 1 * unit_struct)
   expect_equal(cost_ll_irs_structure(n_sprayed = 2), 2 * unit_struct)
   expect_equal(cost_ll_irs_structure(n_sprayed = c(1, 2)), c(1, 2) * unit_struct)
 
   expect_equal(
     cost_ll_irs_structure(n_sprayed = 1, cost_per_structure_sprayed  = 2, target_year = 2024),
-    1 * inflation_adjust(2, 1999, 2024)
+    1 * inflation_adjust(2, 2020, 2024)
   )
 
   expect_error(cost_ll_irs_structure(n_sprayed = -1), "All n_sprayed estimates must be >= 0")

--- a/tests/testthat/test-pmc.R
+++ b/tests/testthat/test-pmc.R
@@ -1,12 +1,12 @@
 test_that("PMC costing", {
-  unit <- inflation_adjust(0.3894, 1999, 2024)
+  unit <- inflation_adjust(0.3894, 2007, 2024)
   expect_equal(cost_pmc(n_doses = 1), 1 * unit)
   expect_equal(cost_pmc(n_doses = 2), 2 * unit)
   expect_equal(cost_pmc(n_doses = c(1, 2)), c(1, 2) * unit)
 
   expect_equal(
     cost_pmc(n_doses = 1, pmc_cost_per_dose_delivered  = 2, target_year = 2024),
-    1 * inflation_adjust(2, 1999, 2024)
+    1 * inflation_adjust(2, 2007, 2024)
   )
 
   expect_error(cost_pmc(n_doses = -1), "All n_doses estimates must be >= 0")

--- a/tests/testthat/test-set-options.R
+++ b/tests/testthat/test-set-options.R
@@ -1,0 +1,13 @@
+test_that("set_region sets global option", {
+  old <- getOption("treasure.region")
+  set_region("South Asia")
+  expect_equal(getOption("treasure.region"), "South Asia")
+  options(treasure.region = old)
+})
+
+test_that("set_target_year sets global option", {
+  old <- getOption("treasure.target_year")
+  set_target_year(2030)
+  expect_equal(getOption("treasure.target_year"), 2030)
+  options(treasure.target_year = old)
+})

--- a/tests/testthat/test-smc.R
+++ b/tests/testthat/test-smc.R
@@ -1,12 +1,12 @@
 test_that("SMC costing", {
-  unit <- inflation_adjust(0.9075, 1999, 2024)
+  unit <- inflation_adjust(0.9075, 2016, 2024)
   expect_equal(cost_smc(n_doses = 1), 1 * unit)
   expect_equal(cost_smc(n_doses = 2), 2 * unit)
   expect_equal(cost_smc(n_doses = c(1, 2)), c(1, 2) * unit)
 
   expect_equal(
     cost_smc(n_doses = 1, smc_cost_per_dose_delivered  = 2, target_year = 2024),
-    1 * inflation_adjust(2, 1999, 2024)
+    1 * inflation_adjust(2, 2016, 2024)
   )
 
   expect_error(cost_smc(n_doses = -1), "All n_doses estimates must be >= 0")

--- a/tests/testthat/test-surveillance.R
+++ b/tests/testthat/test-surveillance.R
@@ -1,12 +1,12 @@
 test_that("multiplication works", {
-  unit <- inflation_adjust(0.05, 1999, 2024)
+  unit <- inflation_adjust(0.05, 2017, 2024)
   expect_equal(cost_surveillance(pop_at_risk = 1), 1 * unit)
   expect_equal(cost_surveillance(pop_at_risk = 2), 2 * unit)
   expect_equal(cost_surveillance(pop_at_risk = c(1, 2)), c(1, 2) * unit)
 
   expect_equal(
     cost_surveillance(pop_at_risk = 1, cost_per_pop_at_risk  = 2, target_year = 2024),
-    1 * inflation_adjust(2, 1999, 2024)
+    1 * inflation_adjust(2, 2017, 2024)
   )
 
   expect_error(cost_surveillance(pop_at_risk = -1), "All pop_at_risk estimates must be >= 0")

--- a/tests/testthat/test-vaccine.R
+++ b/tests/testthat/test-vaccine.R
@@ -1,5 +1,5 @@
 test_that("RTSS costing", {
-  unit <- inflation_adjust(10.02 + 1.52 + 1.48, 1999, 2024)
+  unit <- inflation_adjust(10.02 + 3.80 + 1.48, 2024, 2024)
   expect_equal(cost_rtss(n_doses = 1), 1 * unit)
   expect_equal(cost_rtss(n_doses = 2), 2 * unit)
   expect_equal(cost_rtss(n_doses = c(1, 2)), c(1, 2) * unit)
@@ -8,7 +8,7 @@ test_that("RTSS costing", {
     cost_rtss(n_doses = 1, rtss_cost_per_dose  = 2,
                rtss_consumables_cost  = 3, rtss_delivery_cost = 4,
                target_year = 2024),
-    1 * inflation_adjust(2 + 3 + 4, 1999, 2024)
+    1 * inflation_adjust(2 + 3 + 4, 2024, 2024)
   )
 
   expect_error(cost_rtss(n_doses = -1), "All n_doses estimates must be >= 0")
@@ -18,7 +18,7 @@ test_that("RTSS costing", {
 })
 
 test_that("R21 costing", {
-  unit <- inflation_adjust(4 + 1.52 + 1.48, 1999, 2024)
+  unit <- inflation_adjust(4 + 3.80 + 1.48, 2024, 2024)
   expect_equal(cost_r21(n_doses = 1), 1 * unit)
   expect_equal(cost_r21(n_doses = 2), 2 * unit)
   expect_equal(cost_r21(n_doses = c(1, 2)), c(1, 2) * unit)
@@ -27,7 +27,7 @@ test_that("R21 costing", {
     cost_r21(n_doses = 1, r21_cost_per_dose  = 2,
               r21_consumables_cost  = 3, r21_delivery_cost = 4,
               target_year = 2024),
-    1 * inflation_adjust(2 + 3 + 4, 1999, 2024)
+    1 * inflation_adjust(2 + 3 + 4, 2024, 2024)
   )
 
   expect_error(cost_r21(n_doses = -1), "All n_doses estimates must be >= 0")


### PR DESCRIPTION
## Summary
- update all costing tests for new CPI inputs
- expand inflation_adjust tests
- test option setter helpers

## Testing
- `NA`

------
https://chatgpt.com/codex/tasks/task_e_685026f4c2688326ab470b6651c0845d