### PR TITLE
Add vignette demonstrating commodity costing

### DIFF
--- a/vignettes/commodity-costs.Rmd
+++ b/vignettes/commodity-costs.Rmd
@@ -1,0 +1,133 @@
+---
+title: "Estimating commodities and costs"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Estimating commodities and costs}
+  %\VignetteEngine{rmarkdown::html_vignette}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+This vignette provides a brief example of estimating the number of
+commodities required for a simple scenario and how these can be
+converted into costs.  We use two small data sets as examples.
+
+## Bed nets
+
+First we consider some basic intervention information that includes
+population at risk (`par`) and a target level of insecticide treated net
+(ITN) usage by year.
+
+```{r itn-data}
+interventions <- data.frame(
+  year    = 1:6,
+  itn_use = c(0, 0.6, 0.5, 0.2, 0.5, 0.4),
+  par     = rep(1000, 6)
+)
+interventions
+```
+
+To determine how many nets are required we can use `commodity_nets()`.
+Here we assume a constant usage rate, distributions on the first day of
+each year, and a half life of two years.
+
+```{r nets}
+dist_steps <- cumsum(c(1, rep(365, 5)))
+crop_steps <- dist_steps + 183
+half_life  <- 730
+use_rate   <- 0.5
+
+interventions$n_nets <- commodity_nets(
+  usage                 = interventions$itn_use,
+  use_rate              = use_rate,
+  distribution_timesteps = dist_steps,
+  crop_timesteps        = crop_steps,
+  half_life             = half_life,
+  par                   = interventions$par
+)
+
+interventions$cost_nets <- cost_llin(interventions$n_nets)
+
+interventions
+```
+
+```{r plot-nets, fig.cap="Nets required by year"}
+barplot(
+  interventions$n_nets,
+  names.arg = interventions$year,
+  xlab = "Year",
+  ylab = "Number of nets"
+)
+```
+
+## Cases
+
+The second example uses case data by year and age band.  For
+simplicity we assume constant treatment coverage and diagnostic usage.
+
+```{r case-data}
+cases <- data.frame(
+  year      = rep(1:6, each = 3),
+  age_lower = rep(c(0, 5, 15), 6),
+  age_upper = rep(c(5, 15, 100), 6),
+  cases     = rep(rpois(6, 100), each = 3),
+  tx_cov    = rep(c(0, 0.3, 0.8), each = 3),
+  par       = rep(300, 6 * 3)
+)
+cases
+```
+
+We can estimate the number of rapid diagnostic tests (RDTs) and ACT
+doses required using `commodity_rdt_tests()` and `commodity_al_doses()`.
+The age specific dose multipliers are determined by the `age_upper`
+values.
+
+```{r commodities}
+prop_rdt <- 1
+prop_act <- 1
+
+cases$n_rdt <- commodity_rdt_tests(
+  n_cases            = cases$cases,
+  treatment_coverage = cases$tx_cov,
+  proportion_rdt     = prop_rdt
+)
+
+cases$n_act <- commodity_al_doses(
+  n_cases            = cases$cases,
+  treatment_coverage = cases$tx_cov,
+  proportion_act     = prop_act,
+  age_upper          = cases$age_upper
+)
+
+cases
+```
+
+Costs can then be added using the corresponding costing functions.
+
+```{r case-costs}
+cases$cost_rdt <- cost_rdt(cases$n_rdt)
+cases$cost_act <- cost_al(cases$n_act)
+head(cases)
+```
+
+```{r plot-cases, fig.cap="RDTs and ACT doses by year"}
+barplot(
+  rbind(cases$n_rdt, cases$n_act),
+  beside = TRUE,
+  names.arg = cases$year,
+  legend.text = c("RDTs", "ACT doses"),
+  xlab = "Year",
+  ylab = "Number"
+)
+```
+
+The examples above show the basic approach for moving from programme
+data to estimates of commodity requirements and associated costs.  More
+complex scenarios can be handled in the same way by adjusting the input
+arguments to the commodity and costing functions.


### PR DESCRIPTION
## Summary
- add `commodity-costs.Rmd` showing how to estimate commodities and apply basic costs
- refine examples to include treatment coverage and age bounds
- add simple barplots for nets and diagnostics

## Testing
- `R CMD build .` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685969c7ecc883268ebdce54f00293a4