### PR TITLE
Vectorise commodity arguments

### DIFF
--- a/R/bet_nets.R
+++ b/R/bet_nets.R
@@ -28,6 +28,14 @@ commodity_nets <- function(usage, use_rate, distribution_timesteps, crop_timeste
     is.numeric(half_life),
     is.numeric(par)
   )
+  check_lengths(
+    usage,
+    use_rate,
+    distribution_timesteps,
+    crop_timesteps,
+    half_life,
+    par
+  )
   stopifnot(
     all(usage >= 0 & usage <= 1),
     all(use_rate >= 0 & use_rate <= 1),
@@ -36,7 +44,6 @@ commodity_nets <- function(usage, use_rate, distribution_timesteps, crop_timeste
     all(half_life >= 0),
     all(par >= 0)
   )
-  check_lengths(usage, use_rate, distribution_timesteps, crop_timesteps, half_life, par)
 
   access <- netz::usage_to_access(usage = usage, use_rate = use_rate)
   crop <- netz::access_to_crop(access = access)

--- a/R/bet_nets.R
+++ b/R/bet_nets.R
@@ -1,16 +1,16 @@
 #' Estimate the number of bed nets required to match usage target
 #'
-#' @param usage A single value or vector of desired target usages (\%) to model.
-#' @param use_rate A single value or vector of usage rates.
-#' @param distribution_timesteps Timesteps of distributions (days). By default,
+#' @param usage Desired target usages (\%) to model. Numeric scalar or vector.
+#' @param use_rate Usage rates. Numeric scalar or vector.
+#' @param distribution_timesteps Distribution timesteps (days). Numeric scalar or vector. By default,
 #' we can assume that net distributions happen on the first day of each year.
 #' For example c(1, 366)
-#' @param crop_timesteps Timesteps of crop estimates (days). If assuming distribtions
+#' @param crop_timesteps Crop estimate timesteps (days). Numeric scalar or vector. If assuming distributions
 #' occur on the first day of each year, a reasonable assumption would be that the
 #' crop (and therefore corresponding usage) estimates were taken at the mid-point of each year.
 #' For example c(1, 366) + 183.
-#' @param half_life Country-specific half-life of nets in days.
-#' @param par Population at risk estimates. A vector the same length as usage
+#' @param half_life Country-specific net half-life in days. Numeric scalar or vector.
+#' @param par Population at risk estimates. Numeric scalar or vector.
 #' @param ... additional arguments for the crop_to_distribution function in netz
 #'
 #' @return Number of nets required to match usage targets
@@ -33,13 +33,10 @@ commodity_nets <- function(usage, use_rate, distribution_timesteps, crop_timeste
     all(use_rate >= 0 & use_rate <= 1),
     all(distribution_timesteps >= 0),
     all(crop_timesteps >= 0),
-    half_life >= 0,
+    all(half_life >= 0),
     all(par >= 0)
   )
-  stopifnot(
-    length(half_life) == 1,
-    length(usage) == length(par)
-  )
+  check_lengths(usage, use_rate, distribution_timesteps, crop_timesteps, half_life, par)
 
   access <- netz::usage_to_access(usage = usage, use_rate = use_rate)
   crop <- netz::access_to_crop(access = access)

--- a/R/dx_tx.R
+++ b/R/dx_tx.R
@@ -1,9 +1,9 @@
 #' Estimate total number of RDT diagnostics required
 #'
-#' @param n_cases Vector of malaria case numbers
-#' @param treatment_coverage Vector of treatment coverage
-#' @param proportion_rdt Vector of proportion of diagnostics that are RDT
-#' @param proportion_tested A scalar value of proportion of treated cases that are tested
+#' @param n_cases Malaria case numbers. Numeric scalar or vector.
+#' @param treatment_coverage Treatment coverage. Numeric scalar or vector.
+#' @param proportion_rdt Proportion of diagnostics that are RDT. Numeric scalar or vector.
+#' @param proportion_tested Proportion of treated cases that are tested. Numeric scalar or vector.
 #'
 #' @return Vector of the number of RDT tests
 #'
@@ -21,11 +21,7 @@ commodity_rdt_tests <- function(n_cases, treatment_coverage, proportion_rdt, pro
     all(proportion_rdt >= 0 & proportion_rdt <= 1),
     all(proportion_tested >= 0 & proportion_tested <= 1)
   )
-  stopifnot(
-    length(n_cases) == length(treatment_coverage),
-    length(n_cases) == length(proportion_rdt),
-    length(proportion_tested) == 1
-  )
+  check_lengths(n_cases, treatment_coverage, proportion_rdt, proportion_tested)
 
   round(n_cases * treatment_coverage * proportion_rdt * proportion_tested)
 }
@@ -33,7 +29,7 @@ commodity_rdt_tests <- function(n_cases, treatment_coverage, proportion_rdt, pro
 #' Estimate total number of microscopy diagnostics required
 #'
 #' @inheritParams commodity_rdt_tests
-#' @param proportion_microscopy Vector of proportion of diagnostics that are microscopy
+#' @param proportion_microscopy Proportion of diagnostics that are microscopy. Numeric scalar or vector.
 #'
 #' @return Vector of the number of microscopy tests
 #'
@@ -51,23 +47,19 @@ commodity_microscopy_tests <- function(n_cases, treatment_coverage, proportion_m
     all(proportion_microscopy >= 0 & proportion_microscopy <= 1),
     all(proportion_tested >= 0 & proportion_tested <= 1)
   )
-  stopifnot(
-    length(n_cases) == length(treatment_coverage),
-    length(n_cases) == length(proportion_microscopy),
-    length(proportion_tested) == 1
-  )
+  check_lengths(n_cases, treatment_coverage, proportion_microscopy, proportion_tested)
 
   round(n_cases * treatment_coverage * proportion_microscopy * proportion_tested)
 }
 
 #' Estimate total number of RDT diagnostics required as a result of non malarial fevers
 #'
-#' @param n_nmf Vector of non malarial fever case numbers
-#' @param treatment_coverage Vector of treatment coverage
-#' @param proportion_rdt Vector of proportion of diagnostics that are RDT
-#' @param proportion_tested Proportion of nmfs that are tested
-#' @param pfpr Prevalence
-#' @param pfpr_threshold Prevalence threshold at which it is assummed NMF are not suspected (and subsequently tested) to be malaria
+#' @param n_nmf Non malarial fever case numbers. Numeric scalar or vector.
+#' @param treatment_coverage Treatment coverage. Numeric scalar or vector.
+#' @param proportion_rdt Proportion of diagnostics that are RDT. Numeric scalar or vector.
+#' @param proportion_tested Proportion of NMFs that are tested. Numeric scalar or vector.
+#' @param pfpr Prevalence. Numeric scalar or vector.
+#' @param pfpr_threshold Prevalence threshold at which it is assumed NMF are not suspected (and subsequently tested) to be malaria. Numeric scalar or vector.
 #'
 #' @return Vector of the number of RDTs tests used on NMFs
 #'
@@ -87,15 +79,9 @@ commodity_nmf_rdt_tests <- function(n_nmf, treatment_coverage, proportion_rdt, p
     all(proportion_rdt >= 0 & proportion_rdt <= 1),
     all(proportion_tested >= 0 & proportion_tested <= 1),
     all(pfpr >= 0 & pfpr <= 1),
-    pfpr_threshold >= 0 & pfpr_threshold <= 1
+    all(pfpr_threshold >= 0 & pfpr_threshold <= 1)
   )
-  stopifnot(
-    length(pfpr_threshold) == 1,
-    length(n_nmf) == length(treatment_coverage),
-    length(n_nmf) == length(proportion_rdt),
-    length(proportion_tested) == 1,
-    length(n_nmf) == length(pfpr)
-  )
+  check_lengths(n_nmf, treatment_coverage, proportion_rdt, proportion_tested, pfpr, pfpr_threshold)
 
   ifelse(pfpr > pfpr_threshold, round(n_nmf * treatment_coverage * proportion_rdt * proportion_tested), 0)
 }
@@ -103,7 +89,7 @@ commodity_nmf_rdt_tests <- function(n_nmf, treatment_coverage, proportion_rdt, p
 #' Estimate total number of microscopy diagnostics required as a result of non malarial fevers
 #'
 #' @inheritParams commodity_nmf_rdt_tests
-#' @param proportion_microscopy Vector of proportion of diagnostics that are microscopy
+#' @param proportion_microscopy Proportion of diagnostics that are microscopy. Numeric scalar or vector.
 #'
 #' @return Vector of the number of microscopy tests used on NMFs
 #'
@@ -123,15 +109,9 @@ commodity_nmf_microscopy_tests <- function(n_nmf, treatment_coverage, proportion
     all(proportion_microscopy >= 0 & proportion_microscopy <= 1),
     all(proportion_tested >= 0 & proportion_tested <= 1),
     all(pfpr >= 0 & pfpr <= 1),
-    pfpr_threshold >= 0 & pfpr_threshold <= 1
+    all(pfpr_threshold >= 0 & pfpr_threshold <= 1)
   )
-  stopifnot(
-    length(pfpr_threshold) == 1,
-    length(n_nmf) == length(treatment_coverage),
-    length(n_nmf) == length(proportion_microscopy),
-    length(proportion_tested) == 1,
-    length(n_nmf) == length(pfpr)
-  )
+  check_lengths(n_nmf, treatment_coverage, proportion_microscopy, proportion_tested, pfpr, pfpr_threshold)
 
   ifelse(pfpr > pfpr_threshold, round(n_nmf * treatment_coverage * proportion_microscopy * proportion_tested), 0)
 }
@@ -150,10 +130,10 @@ commodity_nmf_microscopy_tests <- function(n_nmf, treatment_coverage, proportion
 #' So course for a single adult (weighing >=35kg) may constitute
 #' 3 days x 2 times daily x 4 doses (4 x 20/120mg = 80/480mg) = 24 doses.
 #'
-#' @param n_cases Vector of malaria case numbers by age band.
-#' @param treatment_coverage Vector of treatment coverage proportions by age band.
-#' @param proportion_act Vector of proportion of treatments that are ACTs by age band.
-#' @param age_upper Vector of upper bounds for each age group.
+#' @param n_cases Malaria case numbers by age band. Numeric scalar or vector.
+#' @param treatment_coverage Treatment coverage proportions by age band. Numeric scalar or vector.
+#' @param proportion_act Proportion of treatments that are ACTs by age band. Numeric scalar or vector.
+#' @param age_upper Upper bounds for each age group. Numeric scalar or vector.
 #'
 #' @return A vector giving the number of 20/120mg Artemether + lumefantrine ACT doses required per age group.
 #' @export
@@ -170,11 +150,7 @@ commodity_al_doses <- function(n_cases, treatment_coverage, proportion_act, age_
     all(proportion_act >= 0 & proportion_act <= 1),
     all(age_upper >= 0)
   )
-  stopifnot(
-    length(n_cases) == length(treatment_coverage),
-    length(n_cases) == length(age_upper),
-    length(n_cases) == length(proportion_act)
-  )
+  check_lengths(n_cases, treatment_coverage, proportion_act, age_upper)
 
   # Dose multipliers per age band (number of 20/120mg doses per course)
   doses_per_course_child   <- 3 * 2 * 1     # 6 doses
@@ -210,10 +186,10 @@ commodity_al_doses <- function(n_cases, treatment_coverage, proportion_act, age_
 #' }
 #' So course for a single adult may constitute approximately 10 doses.
 #'
-#' @param n_cases Vector of malaria case numbers by age band.
-#' @param treatment_coverage Vector of treatment coverage proportions.
-#' @param proportion_non_act Vector of proportion of treatments that are non-ACT (assumed chloroquine).
-#' @param age_upper Vector of upper bounds for each age group.
+#' @param n_cases Malaria case numbers by age band. Numeric scalar or vector.
+#' @param treatment_coverage Treatment coverage proportions. Numeric scalar or vector.
+#' @param proportion_non_act Proportion of treatments that are non-ACT (assumed chloroquine). Numeric scalar or vector.
+#' @param age_upper Upper bounds for each age group. Numeric scalar or vector.
 #'
 #' @return A vector giving the number of 250mg chloroquine doses required per age group.
 #' @export
@@ -230,11 +206,7 @@ commodity_chloroquine_doses <- function(n_cases, treatment_coverage, proportion_
     all(proportion_non_act >= 0 & proportion_non_act <= 1),
     all(age_upper >= 0)
   )
-  stopifnot(
-    length(n_cases) == length(treatment_coverage),
-    length(n_cases) == length(age_upper),
-    length(n_cases) == length(proportion_non_act)
-  )
+  check_lengths(n_cases, treatment_coverage, proportion_non_act, age_upper)
 
   # Dose multipliers per age band
   doses_per_course_child   <- 3
@@ -272,12 +244,12 @@ commodity_chloroquine_doses <- function(n_cases, treatment_coverage, proportion_
 #' So course for a single adult (weighing >=35kg) may constitute
 #' 3 days x 2 times daily x 4 doses (4 x 20/120mg = 80/480mg) = 24 doses.
 #'
-#' @param n_nmf Vector of non malarial fever case numbers by age band.
-#' @param treatment_coverage Vector of treatment coverage proportions.
-#' @param proportion_act Vector of proportion of treatments that are ACTs.
-#' @param age_upper Vector of upper bounds for each age group.
-#' @param pfpr Prevalence
-#' @param pfpr_threshold Prevalence threshold at which it is assummed NMF are not suspected (and subsequently tested) to be malaria
+#' @param n_nmf Non malarial fever case numbers by age band. Numeric scalar or vector.
+#' @param treatment_coverage Treatment coverage proportions. Numeric scalar or vector.
+#' @param proportion_act Proportion of treatments that are ACTs. Numeric scalar or vector.
+#' @param age_upper Upper bounds for each age group. Numeric scalar or vector.
+#' @param pfpr Prevalence. Numeric scalar or vector.
+#' @param pfpr_threshold Prevalence threshold at which it is assumed NMF are not suspected (and subsequently tested) to be malaria. Numeric scalar or vector.
 #'
 #' @return A vector giving the number of 20/120mg Artemether + lumefantrine ACT doses required per age group.
 #' @export
@@ -296,15 +268,9 @@ commodity_nmf_al_doses <- function(n_nmf, treatment_coverage, proportion_act, ag
     all(proportion_act >= 0 & proportion_act <= 1),
     all(age_upper >= 0),
     all(pfpr >= 0 & pfpr <= 1),
-    pfpr_threshold >= 0 & pfpr_threshold <= 1
+    all(pfpr_threshold >= 0 & pfpr_threshold <= 1)
   )
-  stopifnot(
-    length(pfpr_threshold) == 1,
-    length(n_nmf) == length(treatment_coverage),
-    length(n_nmf) == length(age_upper),
-    length(n_nmf) == length(proportion_act),
-    length(n_nmf) == length(pfpr)
-  )
+  check_lengths(n_nmf, treatment_coverage, proportion_act, age_upper, pfpr, pfpr_threshold)
 
   # Dose multipliers per age band (number of 20/120mg doses per course)
   doses_per_course_child   <- 3 * 2 * 1     # 6 doses

--- a/R/dx_tx.R
+++ b/R/dx_tx.R
@@ -15,13 +15,13 @@ commodity_rdt_tests <- function(n_cases, treatment_coverage, proportion_rdt, pro
     is.numeric(proportion_rdt),
     is.numeric(proportion_tested)
   )
+  check_lengths(n_cases, treatment_coverage, proportion_rdt, proportion_tested)
   stopifnot(
     all(n_cases >= 0),
     all(treatment_coverage >= 0 & treatment_coverage <= 1),
     all(proportion_rdt >= 0 & proportion_rdt <= 1),
     all(proportion_tested >= 0 & proportion_tested <= 1)
   )
-  check_lengths(n_cases, treatment_coverage, proportion_rdt, proportion_tested)
 
   round(n_cases * treatment_coverage * proportion_rdt * proportion_tested)
 }
@@ -41,13 +41,13 @@ commodity_microscopy_tests <- function(n_cases, treatment_coverage, proportion_m
     is.numeric(proportion_microscopy),
     is.numeric(proportion_tested)
   )
+  check_lengths(n_cases, treatment_coverage, proportion_microscopy, proportion_tested)
   stopifnot(
     all(n_cases >= 0),
     all(treatment_coverage >= 0 & treatment_coverage <= 1),
     all(proportion_microscopy >= 0 & proportion_microscopy <= 1),
     all(proportion_tested >= 0 & proportion_tested <= 1)
   )
-  check_lengths(n_cases, treatment_coverage, proportion_microscopy, proportion_tested)
 
   round(n_cases * treatment_coverage * proportion_microscopy * proportion_tested)
 }
@@ -73,6 +73,7 @@ commodity_nmf_rdt_tests <- function(n_nmf, treatment_coverage, proportion_rdt, p
     is.numeric(pfpr),
     is.numeric(pfpr_threshold)
   )
+  check_lengths(n_nmf, treatment_coverage, proportion_rdt, proportion_tested, pfpr, pfpr_threshold)
   stopifnot(
     all(n_nmf >= 0),
     all(treatment_coverage >= 0 & treatment_coverage <= 1),
@@ -81,7 +82,6 @@ commodity_nmf_rdt_tests <- function(n_nmf, treatment_coverage, proportion_rdt, p
     all(pfpr >= 0 & pfpr <= 1),
     all(pfpr_threshold >= 0 & pfpr_threshold <= 1)
   )
-  check_lengths(n_nmf, treatment_coverage, proportion_rdt, proportion_tested, pfpr, pfpr_threshold)
 
   ifelse(pfpr > pfpr_threshold, round(n_nmf * treatment_coverage * proportion_rdt * proportion_tested), 0)
 }
@@ -103,6 +103,7 @@ commodity_nmf_microscopy_tests <- function(n_nmf, treatment_coverage, proportion
     is.numeric(pfpr),
     is.numeric(pfpr_threshold)
   )
+  check_lengths(n_nmf, treatment_coverage, proportion_microscopy, proportion_tested, pfpr, pfpr_threshold)
   stopifnot(
     all(n_nmf >= 0),
     all(treatment_coverage >= 0 & treatment_coverage <= 1),
@@ -111,7 +112,6 @@ commodity_nmf_microscopy_tests <- function(n_nmf, treatment_coverage, proportion
     all(pfpr >= 0 & pfpr <= 1),
     all(pfpr_threshold >= 0 & pfpr_threshold <= 1)
   )
-  check_lengths(n_nmf, treatment_coverage, proportion_microscopy, proportion_tested, pfpr, pfpr_threshold)
 
   ifelse(pfpr > pfpr_threshold, round(n_nmf * treatment_coverage * proportion_microscopy * proportion_tested), 0)
 }
@@ -144,13 +144,13 @@ commodity_al_doses <- function(n_cases, treatment_coverage, proportion_act, age_
     is.numeric(proportion_act),
     is.numeric(age_upper)
   )
+  check_lengths(n_cases, treatment_coverage, proportion_act, age_upper)
   stopifnot(
     all(n_cases >= 0),
     all(treatment_coverage >= 0 & treatment_coverage <= 1),
     all(proportion_act >= 0 & proportion_act <= 1),
     all(age_upper >= 0)
   )
-  check_lengths(n_cases, treatment_coverage, proportion_act, age_upper)
 
   # Dose multipliers per age band (number of 20/120mg doses per course)
   doses_per_course_child   <- 3 * 2 * 1     # 6 doses
@@ -200,13 +200,13 @@ commodity_chloroquine_doses <- function(n_cases, treatment_coverage, proportion_
     is.numeric(proportion_non_act),
     is.numeric(age_upper)
   )
+  check_lengths(n_cases, treatment_coverage, proportion_non_act, age_upper)
   stopifnot(
     all(n_cases >= 0),
     all(treatment_coverage >= 0 & treatment_coverage <= 1),
     all(proportion_non_act >= 0 & proportion_non_act <= 1),
     all(age_upper >= 0)
   )
-  check_lengths(n_cases, treatment_coverage, proportion_non_act, age_upper)
 
   # Dose multipliers per age band
   doses_per_course_child   <- 3
@@ -262,6 +262,7 @@ commodity_nmf_al_doses <- function(n_nmf, treatment_coverage, proportion_act, ag
     is.numeric(pfpr),
     is.numeric(pfpr_threshold)
   )
+  check_lengths(n_nmf, treatment_coverage, proportion_act, age_upper, pfpr, pfpr_threshold)
   stopifnot(
     all(n_nmf >= 0),
     all(treatment_coverage >= 0 & treatment_coverage <= 1),
@@ -270,7 +271,6 @@ commodity_nmf_al_doses <- function(n_nmf, treatment_coverage, proportion_act, ag
     all(pfpr >= 0 & pfpr <= 1),
     all(pfpr_threshold >= 0 & pfpr_threshold <= 1)
   )
-  check_lengths(n_nmf, treatment_coverage, proportion_act, age_upper, pfpr, pfpr_threshold)
 
   # Dose multipliers per age band (number of 20/120mg doses per course)
   doses_per_course_child   <- 3 * 2 * 1     # 6 doses

--- a/R/irs.R
+++ b/R/irs.R
@@ -12,12 +12,12 @@ commodity_person_rounds_irs <- function(irs_cov, n_rounds, par){
     is.numeric(n_rounds),
     is.numeric(par)
   )
+  check_lengths(irs_cov, n_rounds, par)
   stopifnot(
     all(irs_cov >= 0 & irs_cov <= 1),
     all(n_rounds >= 0),
     all(par >= 0)
   )
-  check_lengths(irs_cov, n_rounds, par)
 
   round(irs_cov * n_rounds * par)
 }
@@ -38,13 +38,13 @@ commodity_structure_rounds_irs <- function(irs_cov, n_rounds, par, hh_size){
     is.numeric(par),
     is.numeric(hh_size)
   )
+  check_lengths(irs_cov, n_rounds, par, hh_size)
   stopifnot(
     all(irs_cov >= 0 & irs_cov <= 1),
     all(n_rounds >= 0),
     all(par >= 0),
     all(hh_size >= 0)
   )
-  check_lengths(irs_cov, n_rounds, par, hh_size)
 
   round((irs_cov * n_rounds * par) / hh_size)
 }

--- a/R/irs.R
+++ b/R/irs.R
@@ -1,8 +1,8 @@
 #' Number of people-rounds of IRS
 #'
-#' @param irs_cov A vector of IRS coverage per year.
-#' @param n_rounds A vector of the number of spray rounds per year
-#' @param par Population at risk estimates.
+#' @param irs_cov IRS coverage per year. Numeric scalar or vector.
+#' @param n_rounds Number of spray rounds per year. Numeric scalar or vector.
+#' @param par Population at risk estimates. Numeric scalar or vector.
 #'
 #' @return The total number of person-rounds of IRS protection.
 #' @export
@@ -14,13 +14,10 @@ commodity_person_rounds_irs <- function(irs_cov, n_rounds, par){
   )
   stopifnot(
     all(irs_cov >= 0 & irs_cov <= 1),
-    n_rounds >= 0,
+    all(n_rounds >= 0),
     all(par >= 0)
   )
-  stopifnot(
-    length(irs_cov) == length(n_rounds),
-    length(irs_cov) == length(par)
-  )
+  check_lengths(irs_cov, n_rounds, par)
 
   round(irs_cov * n_rounds * par)
 }
@@ -30,7 +27,7 @@ commodity_person_rounds_irs <- function(irs_cov, n_rounds, par){
 #' Assumes 1 structure per household
 #'
 #' @inherit commodity_person_rounds_irs
-#' @param hh_size A vector of the average number of occupants per household
+#' @param hh_size Average number of occupants per household. Numeric scalar or vector.
 #'
 #' @return The total number of structure-rounds of IRS protection.
 #' @export
@@ -43,15 +40,11 @@ commodity_structure_rounds_irs <- function(irs_cov, n_rounds, par, hh_size){
   )
   stopifnot(
     all(irs_cov >= 0 & irs_cov <= 1),
-    n_rounds >= 0,
+    all(n_rounds >= 0),
     all(par >= 0),
-    hh_size >= 0
+    all(hh_size >= 0)
   )
-  stopifnot(
-    length(irs_cov) == length(n_rounds),
-    length(irs_cov) == length(hh_size),
-    length(irs_cov) == length(par)
-  )
+  check_lengths(irs_cov, n_rounds, par, hh_size)
 
   round((irs_cov * n_rounds * par) / hh_size)
 }

--- a/R/pmc.R
+++ b/R/pmc.R
@@ -12,12 +12,12 @@ commodity_doses_pmc <- function(pmc_cov, par_pmc, n_rounds = 3){
     is.numeric(par_pmc),
     is.numeric(n_rounds)
   )
+  check_lengths(pmc_cov, par_pmc, n_rounds)
   stopifnot(
     all(pmc_cov >= 0 & pmc_cov <= 1),
     all(n_rounds >= 0),
     all(par_pmc >= 0)
   )
-  check_lengths(pmc_cov, par_pmc, n_rounds)
 
   round(pmc_cov * n_rounds * par_pmc)
 }

--- a/R/pmc.R
+++ b/R/pmc.R
@@ -1,8 +1,8 @@
 #' Number of doses of PMC
 #'
-#' @param pmc_cov A single value or vector of pmc coverage.
-#' @param n_rounds The number of pmc rounds per year
-#' @param par_pmc Population at risk within pmc-eligible age range estimates.
+#' @param pmc_cov PMC coverage. Numeric scalar or vector.
+#' @param n_rounds Number of pmc rounds per year. Numeric scalar or vector.
+#' @param par_pmc Population at risk within pmc-eligible age range. Numeric scalar or vector.
 #'
 #' @return The total number of pmc doses delivered.
 #' @export
@@ -14,13 +14,10 @@ commodity_doses_pmc <- function(pmc_cov, par_pmc, n_rounds = 3){
   )
   stopifnot(
     all(pmc_cov >= 0 & pmc_cov <= 1),
-    n_rounds >= 0,
+    all(n_rounds >= 0),
     all(par_pmc >= 0)
   )
-  stopifnot(
-    length(n_rounds) == 1,
-    length(pmc_cov) == length(par_pmc)
-  )
+  check_lengths(pmc_cov, par_pmc, n_rounds)
 
   round(pmc_cov * n_rounds * par_pmc)
 }

--- a/R/smc.R
+++ b/R/smc.R
@@ -1,8 +1,8 @@
 #' Number of doses of SMC
 #'
-#' @param smc_cov A single value or vector of SMC coverage.
-#' @param n_rounds A vector of the number of SMC rounds per year
-#' @param par_smc Population at risk within SMC-eligible age range estimates.
+#' @param smc_cov SMC coverage. Numeric scalar or vector.
+#' @param n_rounds Number of SMC rounds per year. Numeric scalar or vector.
+#' @param par_smc Population at risk within SMC-eligible age range. Numeric scalar or vector.
 #'
 #' @return The total number of SMC doses delivered.
 #' @export
@@ -14,13 +14,10 @@ commodity_doses_smc <- function(smc_cov, n_rounds, par_smc){
   )
   stopifnot(
     all(smc_cov >= 0 & smc_cov <= 1),
-    n_rounds >= 0,
+    all(n_rounds >= 0),
     all(par_smc >= 0)
   )
-  stopifnot(
-    length(smc_cov) == length(n_rounds),
-    length(smc_cov) == length(par_smc)
-  )
+  check_lengths(smc_cov, n_rounds, par_smc)
 
   round(smc_cov * n_rounds * par_smc)
 }

--- a/R/smc.R
+++ b/R/smc.R
@@ -12,12 +12,12 @@ commodity_doses_smc <- function(smc_cov, n_rounds, par_smc){
     is.numeric(n_rounds),
     is.numeric(par_smc)
   )
+  check_lengths(smc_cov, n_rounds, par_smc)
   stopifnot(
     all(smc_cov >= 0 & smc_cov <= 1),
     all(n_rounds >= 0),
     all(par_smc >= 0)
   )
-  check_lengths(smc_cov, n_rounds, par_smc)
 
   round(smc_cov * n_rounds * par_smc)
 }

--- a/R/vaccine.R
+++ b/R/vaccine.R
@@ -3,12 +3,11 @@
 #' Note, if duration for full course (primary + boosters) is >1 year, costs for
 #' the full course will be all assigned to the year of the primary series.
 #'
-#' @param vaccine_cov A single value or vector of vaccine coverage.
-#' @param par_vaccine Population at risk within vaccine-eligible age range estimates.
-#' @param n_dose_primary_series Number of doses in the primary series
-#' @param booster_coverage_downscale Captures the drop off in coverage between primary series and
-#' boosters such that `booster coverage = vaccine_cov * booster_coverage_downscale`
-#' @param n_boosters Number of booster doses
+#' @param vaccine_cov Vaccine coverage. Numeric scalar or vector.
+#' @param par_vaccine Population at risk within vaccine-eligible age range. Numeric scalar or vector.
+#' @param n_dose_primary_series Number of doses in the primary series. Numeric scalar or vector.
+#' @param booster_coverage_downscale Capture the drop off in coverage between primary series and boosters such that `booster coverage = vaccine_cov * booster_coverage_downscale`. Numeric scalar or vector.
+#' @param n_boosters Number of booster doses. Numeric scalar or vector.
 #'
 #' @return The total number of vaccine doses delivered.
 #' @export
@@ -23,16 +22,11 @@ commodity_doses_vaccine <- function(vaccine_cov, par_vaccine, n_dose_primary_ser
   stopifnot(
     all(vaccine_cov >= 0 & vaccine_cov <= 1),
     all(par_vaccine >= 0),
-    n_dose_primary_series >= 0,
+    all(n_dose_primary_series >= 0),
     all(booster_coverage_downscale >= 0 & booster_coverage_downscale <= 1),
-    n_boosters >= 0
+    all(n_boosters >= 0)
   )
-  stopifnot(
-    length(n_dose_primary_series) == 1,
-    length(booster_coverage_downscale) == 1,
-    length(n_boosters) == 1,
-    length(vaccine_cov) == length(par_vaccine)
-  )
+  check_lengths(vaccine_cov, par_vaccine, n_dose_primary_series, booster_coverage_downscale, n_boosters)
 
   n_vaccine <- vaccine_cov * par_vaccine
   n_doses_vaccine <- round((n_vaccine * n_dose_primary_series) + (n_vaccine * booster_coverage_downscale * n_boosters))

--- a/R/vaccine.R
+++ b/R/vaccine.R
@@ -19,6 +19,7 @@ commodity_doses_vaccine <- function(vaccine_cov, par_vaccine, n_dose_primary_ser
     is.numeric(booster_coverage_downscale),
     is.numeric(n_boosters)
   )
+  check_lengths(vaccine_cov, par_vaccine, n_dose_primary_series, booster_coverage_downscale, n_boosters)
   stopifnot(
     all(vaccine_cov >= 0 & vaccine_cov <= 1),
     all(par_vaccine >= 0),
@@ -26,7 +27,6 @@ commodity_doses_vaccine <- function(vaccine_cov, par_vaccine, n_dose_primary_ser
     all(booster_coverage_downscale >= 0 & booster_coverage_downscale <= 1),
     all(n_boosters >= 0)
   )
-  check_lengths(vaccine_cov, par_vaccine, n_dose_primary_series, booster_coverage_downscale, n_boosters)
 
   n_vaccine <- vaccine_cov * par_vaccine
   n_doses_vaccine <- round((n_vaccine * n_dose_primary_series) + (n_vaccine * booster_coverage_downscale * n_boosters))

--- a/man/commodity_al_doses.Rd
+++ b/man/commodity_al_doses.Rd
@@ -7,13 +7,13 @@
 commodity_al_doses(n_cases, treatment_coverage, proportion_act, age_upper)
 }
 \arguments{
-\item{n_cases}{Vector of malaria case numbers by age band.}
+\item{n_cases}{Malaria case numbers by age band. Numeric scalar or vector.}
 
-\item{treatment_coverage}{Vector of treatment coverage proportions by age band.}
+\item{treatment_coverage}{Treatment coverage proportions by age band. Numeric scalar or vector.}
 
-\item{proportion_act}{Vector of proportion of treatments that are ACTs by age band.}
+\item{proportion_act}{Proportion of treatments that are ACTs by age band. Numeric scalar or vector.}
 
-\item{age_upper}{Vector of upper bounds for each age group.}
+\item{age_upper}{Upper bounds for each age group. Numeric scalar or vector.}
 }
 \value{
 A vector giving the number of 20/120mg Artemether + lumefantrine ACT doses required per age group.

--- a/man/commodity_chloroquine_doses.Rd
+++ b/man/commodity_chloroquine_doses.Rd
@@ -12,13 +12,13 @@ commodity_chloroquine_doses(
 )
 }
 \arguments{
-\item{n_cases}{Vector of malaria case numbers by age band.}
+\item{n_cases}{Malaria case numbers by age band. Numeric scalar or vector.}
 
-\item{treatment_coverage}{Vector of treatment coverage proportions.}
+\item{treatment_coverage}{Treatment coverage proportions. Numeric scalar or vector.}
 
-\item{proportion_non_act}{Vector of proportion of treatments that are non-ACT (assumed chloroquine).}
+\item{proportion_non_act}{Proportion of treatments that are non-ACT (assumed chloroquine). Numeric scalar or vector.}
 
-\item{age_upper}{Vector of upper bounds for each age group.}
+\item{age_upper}{Upper bounds for each age group. Numeric scalar or vector.}
 }
 \value{
 A vector giving the number of 250mg chloroquine doses required per age group.

--- a/man/commodity_doses_pmc.Rd
+++ b/man/commodity_doses_pmc.Rd
@@ -7,11 +7,11 @@
 commodity_doses_pmc(pmc_cov, par_pmc, n_rounds = 3)
 }
 \arguments{
-\item{pmc_cov}{A single value or vector of pmc coverage.}
+\item{pmc_cov}{PMC coverage. Numeric scalar or vector.}
 
-\item{par_pmc}{Population at risk within pmc-eligible age range estimates.}
+\item{par_pmc}{Population at risk within pmc-eligible age range. Numeric scalar or vector.}
 
-\item{n_rounds}{The number of pmc rounds per year}
+\item{n_rounds}{Number of pmc rounds per year. Numeric scalar or vector.}
 }
 \value{
 The total number of pmc doses delivered.

--- a/man/commodity_doses_smc.Rd
+++ b/man/commodity_doses_smc.Rd
@@ -7,11 +7,11 @@
 commodity_doses_smc(smc_cov, n_rounds, par_smc)
 }
 \arguments{
-\item{smc_cov}{A single value or vector of SMC coverage.}
+\item{smc_cov}{SMC coverage. Numeric scalar or vector.}
 
-\item{n_rounds}{A vector of the number of SMC rounds per year}
+\item{n_rounds}{Number of SMC rounds per year. Numeric scalar or vector.}
 
-\item{par_smc}{Population at risk within SMC-eligible age range estimates.}
+\item{par_smc}{Population at risk within SMC-eligible age range. Numeric scalar or vector.}
 }
 \value{
 The total number of SMC doses delivered.

--- a/man/commodity_doses_vaccine.Rd
+++ b/man/commodity_doses_vaccine.Rd
@@ -13,16 +13,15 @@ commodity_doses_vaccine(
 )
 }
 \arguments{
-\item{vaccine_cov}{A single value or vector of vaccine coverage.}
+\item{vaccine_cov}{Vaccine coverage. Numeric scalar or vector.}
 
-\item{par_vaccine}{Population at risk within vaccine-eligible age range estimates.}
+\item{par_vaccine}{Population at risk within vaccine-eligible age range. Numeric scalar or vector.}
 
-\item{n_dose_primary_series}{Number of doses in the primary series}
+\item{n_dose_primary_series}{Number of doses in the primary series. Numeric scalar or vector.}
 
-\item{booster_coverage_downscale}{Captures the drop off in coverage between primary series and
-boosters such that `booster coverage = vaccine_cov * booster_coverage_downscale`}
+\item{booster_coverage_downscale}{Capture the drop off in coverage between primary series and boosters such that `booster coverage = vaccine_cov * booster_coverage_downscale`. Numeric scalar or vector.}
 
-\item{n_boosters}{Number of booster doses}
+\item{n_boosters}{Number of booster doses. Numeric scalar or vector.}
 }
 \value{
 The total number of vaccine doses delivered.

--- a/man/commodity_microscopy_tests.Rd
+++ b/man/commodity_microscopy_tests.Rd
@@ -12,13 +12,13 @@ commodity_microscopy_tests(
 )
 }
 \arguments{
-\item{n_cases}{Vector of malaria case numbers}
+\item{n_cases}{Malaria case numbers. Numeric scalar or vector.}
 
-\item{treatment_coverage}{Vector of treatment coverage}
+\item{treatment_coverage}{Treatment coverage. Numeric scalar or vector.}
 
-\item{proportion_microscopy}{Vector of proportion of diagnostics that are microscopy}
+\item{proportion_microscopy}{Proportion of diagnostics that are microscopy. Numeric scalar or vector.}
 
-\item{proportion_tested}{A scalar value of proportion of treated cases that are tested}
+\item{proportion_tested}{Proportion of treated cases that are tested. Numeric scalar or vector.}
 }
 \value{
 Vector of the number of microscopy tests

--- a/man/commodity_nets.Rd
+++ b/man/commodity_nets.Rd
@@ -15,22 +15,22 @@ commodity_nets(
 )
 }
 \arguments{
-\item{usage}{A single value or vector of desired target usages (\%) to model.}
+\item{usage}{Desired target usages (\%) to model. Numeric scalar or vector.}
 
-\item{use_rate}{A single value or vector of usage rates.}
+\item{use_rate}{Usage rates. Numeric scalar or vector.}
 
-\item{distribution_timesteps}{Timesteps of distributions (days). By default,
+\item{distribution_timesteps}{Distribution timesteps (days). Numeric scalar or vector. By default,
 we can assume that net distributions happen on the first day of each year.
 For example c(1, 366)}
 
-\item{crop_timesteps}{Timesteps of crop estimates (days). If assuming distribtions
+\item{crop_timesteps}{Crop estimate timesteps (days). Numeric scalar or vector. If assuming distributions
 occur on the first day of each year, a reasonable assumption would be that the
 crop (and therefore corresponding usage) estimates were taken at the mid-point of each year.
 For example c(1, 366) + 183.}
 
-\item{half_life}{Country-specific half-life of nets in days.}
+\item{half_life}{Country-specific net half-life in days. Numeric scalar or vector.}
 
-\item{par}{Population at risk estimates. A vector the same length as usage}
+\item{par}{Population at risk estimates. Numeric scalar or vector.}
 
 \item{...}{additional arguments for the crop_to_distribution function in netz}
 }

--- a/man/commodity_nmf_al_doses.Rd
+++ b/man/commodity_nmf_al_doses.Rd
@@ -14,17 +14,17 @@ commodity_nmf_al_doses(
 )
 }
 \arguments{
-\item{n_nmf}{Vector of non malarial fever case numbers by age band.}
+\item{n_nmf}{Non malarial fever case numbers by age band. Numeric scalar or vector.}
 
-\item{treatment_coverage}{Vector of treatment coverage proportions.}
+\item{treatment_coverage}{Treatment coverage proportions. Numeric scalar or vector.}
 
-\item{proportion_act}{Vector of proportion of treatments that are ACTs.}
+\item{proportion_act}{Proportion of treatments that are ACTs. Numeric scalar or vector.}
 
-\item{age_upper}{Vector of upper bounds for each age group.}
+\item{age_upper}{Upper bounds for each age group. Numeric scalar or vector.}
 
-\item{pfpr}{Prevalence}
+\item{pfpr}{Prevalence. Numeric scalar or vector.}
 
-\item{pfpr_threshold}{Prevalence threshold at which it is assummed NMF are not suspected (and subsequently tested) to be malaria}
+\item{pfpr_threshold}{Prevalence threshold at which it is assumed NMF are not suspected (and subsequently tested) to be malaria. Numeric scalar or vector.}
 }
 \value{
 A vector giving the number of 20/120mg Artemether + lumefantrine ACT doses required per age group.

--- a/man/commodity_nmf_microscopy_tests.Rd
+++ b/man/commodity_nmf_microscopy_tests.Rd
@@ -14,17 +14,17 @@ commodity_nmf_microscopy_tests(
 )
 }
 \arguments{
-\item{n_nmf}{Vector of non malarial fever case numbers}
+\item{n_nmf}{Non malarial fever case numbers. Numeric scalar or vector.}
 
-\item{treatment_coverage}{Vector of treatment coverage}
+\item{treatment_coverage}{Treatment coverage. Numeric scalar or vector.}
 
-\item{proportion_microscopy}{Vector of proportion of diagnostics that are microscopy}
+\item{proportion_microscopy}{Proportion of diagnostics that are microscopy. Numeric scalar or vector.}
 
-\item{proportion_tested}{Proportion of nmfs that are tested}
+\item{proportion_tested}{Proportion of NMFs that are tested. Numeric scalar or vector.}
 
-\item{pfpr}{Prevalence}
+\item{pfpr}{Prevalence. Numeric scalar or vector.}
 
-\item{pfpr_threshold}{Prevalence threshold at which it is assummed NMF are not suspected (and subsequently tested) to be malaria}
+\item{pfpr_threshold}{Prevalence threshold at which it is assumed NMF are not suspected (and subsequently tested) to be malaria. Numeric scalar or vector.}
 }
 \value{
 Vector of the number of microscopy tests used on NMFs

--- a/man/commodity_nmf_rdt_tests.Rd
+++ b/man/commodity_nmf_rdt_tests.Rd
@@ -14,17 +14,17 @@ commodity_nmf_rdt_tests(
 )
 }
 \arguments{
-\item{n_nmf}{Vector of non malarial fever case numbers}
+\item{n_nmf}{Non malarial fever case numbers. Numeric scalar or vector.}
 
-\item{treatment_coverage}{Vector of treatment coverage}
+\item{treatment_coverage}{Treatment coverage. Numeric scalar or vector.}
 
-\item{proportion_rdt}{Vector of proportion of diagnostics that are RDT}
+\item{proportion_rdt}{Proportion of diagnostics that are RDT. Numeric scalar or vector.}
 
-\item{proportion_tested}{Proportion of nmfs that are tested}
+\item{proportion_tested}{Proportion of NMFs that are tested. Numeric scalar or vector.}
 
-\item{pfpr}{Prevalence}
+\item{pfpr}{Prevalence. Numeric scalar or vector.}
 
-\item{pfpr_threshold}{Prevalence threshold at which it is assummed NMF are not suspected (and subsequently tested) to be malaria}
+\item{pfpr_threshold}{Prevalence threshold at which it is assumed NMF are not suspected (and subsequently tested) to be malaria. Numeric scalar or vector.}
 }
 \value{
 Vector of the number of RDTs tests used on NMFs

--- a/man/commodity_person_rounds_irs.Rd
+++ b/man/commodity_person_rounds_irs.Rd
@@ -7,11 +7,11 @@
 commodity_person_rounds_irs(irs_cov, n_rounds, par)
 }
 \arguments{
-\item{irs_cov}{A vector of IRS coverage per year.}
+\item{irs_cov}{IRS coverage per year. Numeric scalar or vector.}
 
-\item{n_rounds}{A vector of the number of spray rounds per year}
+\item{n_rounds}{Number of spray rounds per year. Numeric scalar or vector.}
 
-\item{par}{Population at risk estimates.}
+\item{par}{Population at risk estimates. Numeric scalar or vector.}
 }
 \value{
 The total number of person-rounds of IRS protection.

--- a/man/commodity_rdt_tests.Rd
+++ b/man/commodity_rdt_tests.Rd
@@ -12,13 +12,13 @@ commodity_rdt_tests(
 )
 }
 \arguments{
-\item{n_cases}{Vector of malaria case numbers}
+\item{n_cases}{Malaria case numbers. Numeric scalar or vector.}
 
-\item{treatment_coverage}{Vector of treatment coverage}
+\item{treatment_coverage}{Treatment coverage. Numeric scalar or vector.}
 
-\item{proportion_rdt}{Vector of proportion of diagnostics that are RDT}
+\item{proportion_rdt}{Proportion of diagnostics that are RDT. Numeric scalar or vector.}
 
-\item{proportion_tested}{A scalar value of proportion of treated cases that are tested}
+\item{proportion_tested}{Proportion of treated cases that are tested. Numeric scalar or vector.}
 }
 \value{
 Vector of the number of RDT tests

--- a/man/commodity_structure_rounds_irs.Rd
+++ b/man/commodity_structure_rounds_irs.Rd
@@ -7,13 +7,13 @@
 commodity_structure_rounds_irs(irs_cov, n_rounds, par, hh_size)
 }
 \arguments{
-\item{irs_cov}{A vector of IRS coverage per year.}
+\item{irs_cov}{IRS coverage per year. Numeric scalar or vector.}
 
-\item{n_rounds}{A vector of the number of spray rounds per year}
+\item{n_rounds}{Number of spray rounds per year. Numeric scalar or vector.}
 
-\item{par}{Population at risk estimates.}
+\item{par}{Population at risk estimates. Numeric scalar or vector.}
 
-\item{hh_size}{A vector of the average number of occupants per household}
+\item{hh_size}{Average number of occupants per household. Numeric scalar or vector.}
 }
 \value{
 The total number of structure-rounds of IRS protection.

--- a/tests/testthat/test-irs.R
+++ b/tests/testthat/test-irs.R
@@ -64,11 +64,11 @@ test_that("IRS commodity people rounds", {
   )
   expect_error(
     commodity_person_rounds_irs(irs_cov = c(0.1, 0.2), n_rounds = 3, par = 100),
-    "is not TRUE"
+    "length"
   )
   expect_error(
     commodity_person_rounds_irs(irs_cov = c(0.1, 0.2), n_rounds = c(3, 2), par = 100),
-    "is not TRUE"
+    "length"
   )
 })
 
@@ -85,10 +85,10 @@ test_that("IRS commodity structure rounds", {
   )
   expect_error(
     commodity_structure_rounds_irs(irs_cov = c(0.2, 0.4), n_rounds = 1, par = 50, hh_size = 5),
-    "is not TRUE"
+    "length"
   )
   expect_error(
     commodity_structure_rounds_irs(irs_cov = 0.2, n_rounds = 1, par = 50, hh_size = c(5, 5)),
-    "is not TRUE"
+    "length"
   )
 })

--- a/tests/testthat/test-irs.R
+++ b/tests/testthat/test-irs.R
@@ -62,12 +62,20 @@ test_that("IRS commodity people rounds", {
     commodity_person_rounds_irs(irs_cov = c(0.1, 0.2), n_rounds = rep(3, 2), par = c(100, 50)),
     round(c(0.1 * 3 * 100, 0.2 * 3 * 50))
   )
-  expect_error(
+  expect_equal(
     commodity_person_rounds_irs(irs_cov = c(0.1, 0.2), n_rounds = 3, par = 100),
-    "length"
+    round(c(0.1, 0.2) * 3 * 100)
+  )
+  expect_equal(
+    commodity_person_rounds_irs(irs_cov = c(0.1, 0.2), n_rounds = c(3, 2), par = 100),
+    round(c(0.1, 0.2) * c(3, 2) * 100)
   )
   expect_error(
-    commodity_person_rounds_irs(irs_cov = c(0.1, 0.2), n_rounds = c(3, 2), par = 100),
+    commodity_person_rounds_irs(
+      irs_cov = c(0.1, 0.2, 0.3),
+      n_rounds = c(3, 3),
+      par = c(100, 100, 100)
+    ),
     "length"
   )
 })
@@ -83,12 +91,21 @@ test_that("IRS commodity structure rounds", {
     ),
     round(c(0.2 * 1 * 50, 0.4 * 1 * 50) / 5)
   )
-  expect_error(
+  expect_equal(
     commodity_structure_rounds_irs(irs_cov = c(0.2, 0.4), n_rounds = 1, par = 50, hh_size = 5),
-    "length"
+    round(c(0.2, 0.4) * 1 * 50 / 5)
+  )
+  expect_equal(
+    commodity_structure_rounds_irs(irs_cov = 0.2, n_rounds = 1, par = 50, hh_size = c(5, 5)),
+    round(0.2 * 1 * 50 / c(5, 5))
   )
   expect_error(
-    commodity_structure_rounds_irs(irs_cov = 0.2, n_rounds = 1, par = 50, hh_size = c(5, 5)),
+    commodity_structure_rounds_irs(
+      irs_cov = c(0.2, 0.4, 0.6),
+      n_rounds = c(1, 1),
+      par = c(50, 50, 50),
+      hh_size = c(5, 5, 5)
+    ),
     "length"
   )
 })

--- a/tests/testthat/test-pmc.R
+++ b/tests/testthat/test-pmc.R
@@ -24,6 +24,6 @@ test_that("PMC commodity doses", {
   )
   expect_error(
     commodity_doses_pmc(pmc_cov = c(0.1, 0.2), par_pmc = 100, n_rounds = 3),
-    "is not TRUE"
+    "length"
   )
 })

--- a/tests/testthat/test-pmc.R
+++ b/tests/testthat/test-pmc.R
@@ -22,8 +22,16 @@ test_that("PMC commodity doses", {
     commodity_doses_pmc(pmc_cov = c(0.1, 0.2), par_pmc = c(100, 50), n_rounds = 3),
     round(c(0.1 * 3 * 100, 0.2 * 3 * 50))
   )
-  expect_error(
+  expect_equal(
     commodity_doses_pmc(pmc_cov = c(0.1, 0.2), par_pmc = 100, n_rounds = 3),
+    round(c(0.1, 0.2) * 3 * 100)
+  )
+  expect_error(
+    commodity_doses_pmc(
+      pmc_cov = c(0.1, 0.2, 0.3),
+      par_pmc = c(100, 50),
+      n_rounds = c(3, 3, 3)
+    ),
     "length"
   )
 })

--- a/tests/testthat/test-smc.R
+++ b/tests/testthat/test-smc.R
@@ -22,8 +22,16 @@ test_that("SMC commodity doses", {
     commodity_doses_smc(smc_cov = c(0.1, 0.2), n_rounds = c(3, 3), par_smc = c(100, 50)),
     round(c(0.1 * 3 * 100, 0.2 * 3 * 50))
   )
-  expect_error(
+  expect_equal(
     commodity_doses_smc(smc_cov = c(0.1, 0.2), n_rounds = 3, par_smc = 100),
+    round(c(0.1, 0.2) * 3 * 100)
+  )
+  expect_error(
+    commodity_doses_smc(
+      smc_cov = c(0.1, 0.2, 0.3),
+      n_rounds = c(3, 3),
+      par_smc = c(100, 100, 100)
+    ),
     "length"
   )
 })

--- a/tests/testthat/test-smc.R
+++ b/tests/testthat/test-smc.R
@@ -24,6 +24,6 @@ test_that("SMC commodity doses", {
   )
   expect_error(
     commodity_doses_smc(smc_cov = c(0.1, 0.2), n_rounds = 3, par_smc = 100),
-    "is not TRUE"
+    "length"
   )
 })


### PR DESCRIPTION
## Summary
- allow commodity functions to take scalars or vectors via `check_lengths()`
- tighten argument validation for vectorised inputs
- document new argument recycling behaviour
- update tests for revised error handling

## Testing
- `R CMD check .` *(fails: `bash: R: command not found`)*
- `Rscript -e 'devtools::test()'` *(fails: `bash: Rscript: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68596fc02340832692914b90b4b0e3fd