### PR TITLE
Fix cost function error messages

### DIFF
--- a/R/bet_nets.R
+++ b/R/bet_nets.R
@@ -88,7 +88,7 @@ cost_llin <- function(n_llin, llin_unit_cost = 2.02, llin_delivery_cost = 1.50,
                       input_year = 2024, ...) {
   check_lengths(n_llin, llin_unit_cost, llin_delivery_cost)
   if(any(n_llin < 0)){
-    stop("All llin_n estimates must be >= 0")
+    stop("All n_llin estimates must be >= 0")
   }
   if(any(llin_unit_cost < 0) | any(llin_delivery_cost < 0)){
     stop("LLIN cost inputs must be >= 0")
@@ -130,7 +130,7 @@ cost_pbo_itn <- function(n_pbo_itn, pbo_itn_unit_cost = 2.63,
                          ...) {
   check_lengths(n_pbo_itn, pbo_itn_unit_cost, pbo_itn_delivery_cost)
   if(any(n_pbo_itn < 0)){
-    stop("All llin_n estimates must be >= 0")
+    stop("All n_pbo_itn estimates must be >= 0")
   }
   if(any(pbo_itn_unit_cost < 0) | any(pbo_itn_delivery_cost < 0)){
     stop("PBO cost inputs must be >= 0")
@@ -172,7 +172,7 @@ cost_dualai_itn <- function(n_dualai_itn, dualai_itn_unit_cost = 2.70,
                             ...) {
   check_lengths(n_dualai_itn, dualai_itn_unit_cost, dualai_itn_delivery_cost)
   if(any(n_dualai_itn < 0)){
-    stop("All llin_n estimates must be >= 0")
+    stop("All n_dualai_itn estimates must be >= 0")
   }
   if(any(dualai_itn_unit_cost < 0) | any(dualai_itn_delivery_cost < 0)){
     stop("Dual ai cost inputs must be >= 0")

--- a/R/inflate.R
+++ b/R/inflate.R
@@ -3,8 +3,8 @@ utils::globalVariables("cpi")
 #' Inflate cost to a target year using SSA CPI
 #'
 #' Adjust a given cost from its original year to a specified target year using
-#' the Consumer Price Index (CPI) values from the `cpi` dataset. Note this appoach
-#' uses region median CPIs estimates. For a more correct approach at the country
+#' the Consumer Price Index (CPI) values from the `cpi` dataset. Note this approach
+#' uses region median CPI estimates. For a more correct approach at the country
 #' level see \url{https://linkinghub.elsevier.com/retrieve/pii/S1098-3015(19)32149-7}
 #'
 #' @param cost Numeric value of the original cost.
@@ -18,7 +18,7 @@ utils::globalVariables("cpi")
 #' @return Numeric value of the inflation-adjusted cost in `target_year` dollars.
 #'
 #' @details
-#' The `ssa_cpi` dataset must be included in the package and contain columns:
+#' The `cpi` dataset must be included in the package and contain columns:
 #' - `year`: Calendar year.
 #' - `cpi`: CPI index value for that year.
 #'

--- a/R/smc.R
+++ b/R/smc.R
@@ -48,7 +48,7 @@ commodity_doses_smc <- function(smc_cov, n_rounds, par_smc){
 #'
 #' \url{https://www.thelancet.com/journals/langlo/article/PIIS2214-109X(20)30475-7/fulltext}.
 cost_smc <- function(n_doses, smc_cost_per_dose_delivered = 0.9075,
-                     input_year = 2016.,
+                     input_year = 2016,
                      ...){
   check_lengths(n_doses, smc_cost_per_dose_delivered)
   if(any(n_doses < 0)){

--- a/man/inflation_adjust.Rd
+++ b/man/inflation_adjust.Rd
@@ -30,12 +30,12 @@ Numeric value of the inflation-adjusted cost in `target_year` dollars.
 }
 \description{
 Adjust a given cost from its original year to a specified target year using
-the Consumer Price Index (CPI) values from the `cpi` dataset. Note this appoach
-uses region median CPIs estimates. For a more correct approach at the country
+the Consumer Price Index (CPI) values from the `cpi` dataset. Note this approach
+uses region median CPI estimates. For a more correct approach at the country
 level see \url{https://linkinghub.elsevier.com/retrieve/pii/S1098-3015(19)32149-7}
 }
 \details{
-The `ssa_cpi` dataset must be included in the package and contain columns:
+The `cpi` dataset must be included in the package and contain columns:
 - `year`: Calendar year.
 - `cpi`: CPI index value for that year.
 

--- a/tests/testthat/test-bed-nets.R
+++ b/tests/testthat/test-bed-nets.R
@@ -21,7 +21,7 @@ test_that("LLIN costing", {
     "length"
   )
 
-  expect_error(cost_llin(n_llin = -1), "All llin_n estimates must be >= 0")
+  expect_error(cost_llin(n_llin = -1), "All n_llin estimates must be >= 0")
   expect_error(cost_llin(n_llin = 1, llin_unit_cost = -1), "LLIN cost inputs must be >= 0")
   expect_error(cost_llin(n_llin = 1, llin_delivery_cost = -1), "LLIN cost inputs must be >= 0")
 })
@@ -38,7 +38,7 @@ test_that("Pyrethroid-PBO costing", {
     1 * inflation_adjust(2 + 3, 2024, 2024)
   )
 
-  expect_error(cost_pbo_itn(n_pbo_itn = -1), "All llin_n estimates must be >= 0")
+  expect_error(cost_pbo_itn(n_pbo_itn = -1), "All n_pbo_itn estimates must be >= 0")
   expect_error(cost_pbo_itn(n_pbo_itn = 1, pbo_itn_unit_cost = -1), "PBO cost inputs must be >= 0")
   expect_error(cost_pbo_itn(n_pbo_itn = 1, pbo_itn_delivery_cost = -1), "PBO cost inputs must be >= 0")
 })
@@ -55,7 +55,7 @@ test_that("Pyrethroid-chlorfenapyr costing", {
     1 * inflation_adjust(2 + 3, 2024, 2024)
   )
 
-  expect_error(cost_dualai_itn(n_dualai_itn = -1), "All llin_n estimates must be >= 0")
+  expect_error(cost_dualai_itn(n_dualai_itn = -1), "All n_dualai_itn estimates must be >= 0")
   expect_error(cost_dualai_itn(n_dualai_itn = 1, dualai_itn_unit_cost = -1), "Dual ai cost inputs must be >= 0")
   expect_error(cost_dualai_itn(n_dualai_itn = 1, dualai_itn_delivery_cost = -1), "Dual ai cost inputs must be >= 0")
 })


### PR DESCRIPTION
## Summary
- fix parameter names in bed net cost errors
- correct dataset name in `inflation_adjust()` docs
- remove decimal from SMC default input year
- update unit tests accordingly

## Testing
- `R -q -e 'devtools::document()'` *(fails: command not found)*
- `R -q -e 'devtools::test()'` *(fails: command not found)*
- `R -q -e 'devtools::check()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a74a14d608326bd9f73163a0c0797